### PR TITLE
[fix] 담당 파트 수정(영은)

### DIFF
--- a/src/api/adminApi.ts
+++ b/src/api/adminApi.ts
@@ -206,26 +206,17 @@ export const getAdminNotice = async (params: GetAdminNoticeData) => {
 };
 
 // 공지사항 수정 API
-export const updateAdminNotice = async (
-  formData: FormData,
-  noticeId: string
-) => {
-  const response = await axiosInstance.put(
-    `/v1/admin/notice/${noticeId}`,
-    formData,
-    {
-      headers: {
-        'Content-Type': 'multipart/form-data',
-      },
-    }
-  );
-  return response.data;
-};
+export const updateAdminNotice = async (formData: FormData, noticeId: string) =>
+  axiosInstance.put(`/v1/admin/notice/${noticeId}`, formData, {
+    headers: {
+      'Content-Type': 'multipart/form-data',
+    },
+  });
 
 // 공지사항 삭제 API
 export const deleteAdminNotice = async (noticeId: string) => {
-  const response = await axiosInstance.delete(`/v1/admin/notice/${noticeId}`); // RESTful 형식에 맞게 수정
-  return response.data; // 서버에서 반환하는 데이터
+  const response = await axiosInstance.delete(`/v1/admin/notice/${noticeId}`);
+  return response.data;
 };
 
 // 공지사항 목록에서 개별 공개여부 수정 API

--- a/src/api/userApi.ts
+++ b/src/api/userApi.ts
@@ -16,6 +16,7 @@ export interface UpdatePasswordData {
 }
 
 export interface UpdateOptData {
+  userId: number;
   receiveInfoConsent: boolean;
   receiveMarketingConsent: boolean;
 }
@@ -49,12 +50,9 @@ export const updatePassword = async (PasswordData: UpdatePasswordData) => {
 };
 
 // 회원 정보성 수신동의 변경 API
-export const updateOpt = async (
-  userId: number,
-  updateOptData: UpdateOptData
-) => {
+export const updateOpt = async (updateOptData: UpdateOptData) => {
   const response = await axiosInstance.patch(
-    `/v1/member/consent/${userId}`,
+    `/v1/member/consent/${updateOptData.userId}`,
     updateOptData,
     {
       headers: {

--- a/src/hooks/useUserApi.ts
+++ b/src/hooks/useUserApi.ts
@@ -44,13 +44,10 @@ export const useUpdatePassword = () =>
 // 수신 동의 상태 변경
 export const useUpdateOpt = () =>
   useMutation({
-    mutationFn: async ({
-      userId,
-      updateOptData,
-    }: {
-      userId: number;
-      updateOptData: UpdateOptData;
-    }) => updateOpt(userId, updateOptData),
+    mutationFn: async (updateOptData: UpdateOptData) => {
+      const response = await updateOpt(updateOptData);
+      return response;
+    },
   });
 
 // 회원 탈퇴

--- a/src/pages/Notices.tsx
+++ b/src/pages/Notices.tsx
@@ -22,7 +22,7 @@ const Notices = () => {
   const [searchValue, setSearchValue] = useState('');
   const [curPage, setCurPage] = useState<number>(0);
   const [data, setData] = useState<NoticesStrategyDataProps[]>([]);
-  const [_filteredData, setFilteredData] = useState<NoticesStrategyDataProps[]>(
+  const [filteredData, setFilteredData] = useState<NoticesStrategyDataProps[]>(
     []
   );
   const [totalPage, setTotalPage] = useState(0);
@@ -110,10 +110,10 @@ const Notices = () => {
           handleChange={handleChange}
           handleKeyDown={handleKeyDown}
         />
-        <SearchIcon css={iconStyle} onClick={handleSearch} />{' '}
+        <SearchIcon css={iconStyle} onClick={handleSearch} />
       </div>
       <div css={noticesListStyle}>
-        <Table data={data} columns={columns} />
+        <Table data={filteredData} columns={columns} />
       </div>
       <div css={noticesPaginationStyle}>
         <Pagination

--- a/src/pages/NoticesDetail.tsx
+++ b/src/pages/NoticesDetail.tsx
@@ -25,13 +25,14 @@ interface NoticesDataProps {
   previousWriteDate?: string;
   nextTitle?: string;
   nextWriteDate?: string;
+  previousId?: string;
+  nextId?: string;
   fileDtoList?: FileDto[];
 }
 const NoticesDetail = () => {
   const { noticeId: paramNoticeId } = useParams<{ noticeId: string }>();
   const noticeId = paramNoticeId ? Number(paramNoticeId) : 0;
   const [data, setData] = useState<NoticesDataProps>({ fileDtoList: [] });
-
   const params = { noticeId: String(noticeId) };
   const getNoticeMutation = useGetNoticeDetail(params);
   const navigate = useNavigate();
@@ -163,7 +164,7 @@ const NoticesDetail = () => {
             <div>
               <p>이전</p>
               <span>
-                <Link to={`/notices/${Number(noticeId) - 1}`} css={linkStyle}>
+                <Link to={`/notices/${data.previousId}`} css={linkStyle}>
                   {data.previousTitle}
                 </Link>
               </span>
@@ -176,7 +177,7 @@ const NoticesDetail = () => {
             <div>
               <p>다음</p>
               <p>
-                <Link to={`/notices/${Number(noticeId) + 1}`} css={linkStyle}>
+                <Link to={`/notices/${data.nextId}`} css={linkStyle}>
                   {data.nextTitle}
                 </Link>
               </p>

--- a/src/pages/QnaQuestion.tsx
+++ b/src/pages/QnaQuestion.tsx
@@ -3,6 +3,7 @@ import { css } from '@emotion/react';
 import { useNavigate, useParams } from 'react-router-dom';
 import Button from '@/components/Button';
 import Modal from '@/components/Modal';
+import Tag from '@/components/Tag';
 import TextArea from '@/components/TextArea';
 import TextInput from '@/components/TextInput';
 import { COLOR } from '@/constants/color';
@@ -80,14 +81,16 @@ const QnaQuestion = () => {
       </div>
       <div css={strategyBoxStyle}>
         <div className='strategy-box'>
-          <div className='tags'>
-            <span>
-              <img
-                src={strategyData?.methodIconPath}
-                alt='method icon'
-                css={iconStyle}
-              />
-            </span>
+          <div className='tags' css={tagStyle}>
+            {strategyData.methodIconPath && (
+              <Tag src={strategyData.methodIconPath} alt='method icon' />
+            )}
+            {Array.isArray(strategyData.stockList?.stockIconPath) &&
+              strategyData.stockList?.stockIconPath.map(
+                (stock: string, idx: number) => (
+                  <Tag key={idx} src={stock} alt='stock icon' />
+                )
+              )}
           </div>
           <span>{strategyData?.strategyName}</span>
         </div>
@@ -187,6 +190,11 @@ const strategyBoxStyle = css`
     align-items: center;
     gap: 16px;
   }
+`;
+
+const tagStyle = css`
+  display: flex;
+  gap: 4px;
 `;
 
 const inputBoxStyle = css`

--- a/src/pages/admin/AdminNoticeAdd.tsx
+++ b/src/pages/admin/AdminNoticeAdd.tsx
@@ -112,32 +112,31 @@ const AdminNoticesAdd = () => {
     );
 
     attachedFiles.forEach((fileDtoList) => {
-      formData.append('fileList', fileDtoList.file);
+      if (fileDtoList.file.type.startsWith('image/')) {
+        formData.append('imageDtoList', fileDtoList.file);
+      } else {
+        formData.append('fileList', fileDtoList.file);
+      }
     });
 
     createMutation.mutate(formData, {
       onSuccess: () => {
         navigate(PATH.ADMIN_NOTICES);
       },
-      onError: () => {
+      onError: (error) => {
+        console.error('Submission error:', error);
         openModal('error-submit');
       },
     });
   };
 
   const renderContent = (content: string) => {
-    const lines = content.split('\n');
-    return lines.map((line, index) => {
-      const imageRegex = /!\[image]\((.+)\)/;
-      const match = line.match(imageRegex);
+    const imageRegex = /!\[image]\((.+)\)/g;
+    const images = [...content.matchAll(imageRegex)];
 
-      if (match) {
-        const imageUrl = match[1];
-        return (
-          <img key={index} src={imageUrl} alt='Uploaded' css={imageStyle} />
-        );
-      }
-      return <p key={index}>{line}</p>;
+    return images.map((match, index) => {
+      const imageUrl = match[1];
+      return <img key={index} src={imageUrl} alt='Uploaded' css={imageStyle} />;
     });
   };
 

--- a/src/pages/admin/AdminNoticeAdd.tsx
+++ b/src/pages/admin/AdminNoticeAdd.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { css } from '@emotion/react';
 import AttachFileIcon from '@mui/icons-material/AttachFile';
 import CloseIcon from '@mui/icons-material/Close';
+import ImageIcon from '@mui/icons-material/Image';
 import { useNavigate } from 'react-router-dom';
 import Button from '@/components/Button';
 import Modal from '@/components/Modal';
@@ -57,6 +58,17 @@ const AdminNoticesAdd = () => {
       }));
 
       setAttachedFiles((prev) => [...prev, ...fileArray]);
+      event.target.value = '';
+    }
+  };
+
+  const handleImageInsert = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const { files } = event.target;
+    if (files && files[0]) {
+      const file = files[0];
+      const imageUrl = URL.createObjectURL(file);
+      setNoticeContent((prev) => `${prev}\n![image](${imageUrl})`);
+      event.target.value = '';
     }
   };
 
@@ -88,24 +100,19 @@ const AdminNoticesAdd = () => {
 
     const formData = new FormData();
 
-    const noticeSaveRequestDto = {
+    const noticeModifyRequestDto = {
       noticeTitle,
       noticeContent,
       isOpen: isChecked === 'unclosed',
     };
+
     formData.append(
       'NoticeSaveRequestDto',
-      JSON.stringify(noticeSaveRequestDto)
+      JSON.stringify(noticeModifyRequestDto)
     );
 
-    attachedFiles.forEach((fileDto) => {
-      formData.append('fileList', fileDto.file);
-    });
-
-    attachedFiles.forEach((fileDto) => {
-      if (fileDto.file.type.startsWith('image/')) {
-        formData.append('imageList', fileDto.file);
-      }
+    attachedFiles.forEach((fileDtoList) => {
+      formData.append('fileList', fileDtoList.file);
     });
 
     createMutation.mutate(formData, {
@@ -117,6 +124,31 @@ const AdminNoticesAdd = () => {
       },
     });
   };
+
+  const renderContent = (content: string) => {
+    const lines = content.split('\n');
+    return lines.map((line, index) => {
+      const imageRegex = /!\[image]\((.+)\)/;
+      const match = line.match(imageRegex);
+
+      if (match) {
+        const imageUrl = match[1];
+        return (
+          <img key={index} src={imageUrl} alt='Uploaded' css={imageStyle} />
+        );
+      }
+      return <p key={index}>{line}</p>;
+    });
+  };
+
+  const imageStyle = css`
+    max-width: 150px;
+    max-height: 100px;
+    height: auto;
+    margin: 8px 0;
+    object-fit: cover;
+    border: 1px solid ${COLOR.GRAY100};
+  `;
 
   const handleGoList = () => {
     navigate(PATH.ADMIN_NOTICES);
@@ -137,6 +169,15 @@ const AdminNoticesAdd = () => {
       </div>
       <div css={textAreaIconStyle}>
         <label>
+          <ImageIcon />
+          <input
+            type='file'
+            accept='image/*'
+            onChange={handleImageInsert}
+            style={{ display: 'none' }}
+          />
+        </label>
+        <label>
           <AttachFileIcon />
           <input
             type='file'
@@ -153,6 +194,7 @@ const AdminNoticesAdd = () => {
           handleChange={handleContentChange}
           fullWidth
         />
+        <div css={noticesContentStyle}>{renderContent(noticeContent)}</div>
       </div>
       <div css={noticesDetailMainStyle}>
         <div css={noticesFileStyle}>
@@ -189,7 +231,6 @@ const AdminNoticesAdd = () => {
           </div>
         </div>
       </div>
-
       <div css={btnStyle}>
         <Button
           label='이전'
@@ -209,7 +250,6 @@ const AdminNoticesAdd = () => {
           handleClick={handleSubmitBtn}
         />
       </div>
-
       <Modal
         id='error-input'
         content={
@@ -226,7 +266,6 @@ const AdminNoticesAdd = () => {
           </div>
         }
       />
-
       <Modal
         id='file-size-error'
         content={
@@ -265,8 +304,13 @@ const noticesDetailHeaderStyle = css`
   }
 `;
 
+const noticesContentStyle = css`
+  padding-top: 16px;
+  white-space: pre-line;
+`;
+
 const noticesDetailMainStyle = css`
-  padding: 40px 0 24px;
+  padding-top: 16px;
 `;
 
 const noticesFileStyle = css`
@@ -380,4 +424,5 @@ const modalTextStyle = css`
   margin-top: 32px;
   margin-bottom: 24px;
 `;
+
 export default AdminNoticesAdd;

--- a/src/pages/admin/AdminNoticeEdit.tsx
+++ b/src/pages/admin/AdminNoticeEdit.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react';
 import { css } from '@emotion/react';
 import AttachFileIcon from '@mui/icons-material/AttachFile';
 import CloseIcon from '@mui/icons-material/Close';
+import ImageIcon from '@mui/icons-material/Image';
 import { useParams, useNavigate } from 'react-router-dom';
 import Button from '@/components/Button';
 import Modal from '@/components/Modal';
@@ -29,10 +30,10 @@ const AdminNoticeEdit = () => {
   const [existingFiles, setExistingFiles] = useState<any[]>([]);
   const [newFiles, setNewFiles] = useState<File[]>([]);
   const [deleteFileIds, setDeleteFileIds] = useState<number[]>([]);
+  const [deleteImageIds, setDeleteImageIds] = useState<number[]>([]);
   const { noticeId } = useParams<{ noticeId: string }>();
   const navigate = useNavigate();
   const { openModal } = useModalStore();
-  const [deleteImageIds, setDeleteImageIds] = useState<number[]>([]);
 
   const { data: noticeData, isError } = useGetAdminNoticeEdit(String(noticeId));
 
@@ -57,11 +58,20 @@ const AdminNoticeEdit = () => {
     setContent(e.target.value);
   };
 
-  const handleFileChange = ({
-    target: { files },
-  }: React.ChangeEvent<HTMLInputElement>) => {
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { files } = e.target;
     if (files) {
       setNewFiles((prev) => [...prev, ...Array.from(files)]);
+    }
+  };
+
+  const handleImageInsert = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { files } = e.target;
+    if (files && files[0]) {
+      const file = files[0];
+      const imageUrl = URL.createObjectURL(file);
+      setContent((prev) => `${prev}\n![image](${imageUrl})`);
+      e.target.value = '';
     }
   };
 
@@ -118,6 +128,30 @@ const AdminNoticeEdit = () => {
     );
   };
 
+  const renderContent = (content: string) => {
+    const imageRegex = /!\[image]\((.+)\)/g;
+    const images = [...content.matchAll(imageRegex)];
+
+    return images.map((match, index) => {
+      const imageUrl = match[1];
+      return (
+        <img
+          key={index}
+          src={imageUrl}
+          alt='Uploaded'
+          css={css`
+            max-width: 150px;
+            max-height: 100px;
+            height: auto;
+            margin: 8px 0;
+            object-fit: cover;
+            border: 1px solid ${COLOR.GRAY100};
+          `}
+        />
+      );
+    });
+  };
+
   return (
     <div css={noticesDetailWrapperStyle}>
       <div css={noticesDetailHeaderStyle}>
@@ -132,6 +166,15 @@ const AdminNoticeEdit = () => {
         />
       </div>
       <div css={textAreaIconStyle}>
+        <label>
+          <ImageIcon />
+          <input
+            type='file'
+            accept='image/*'
+            onChange={handleImageInsert}
+            style={{ display: 'none' }}
+          />
+        </label>
         <label>
           <AttachFileIcon />
           <input
@@ -149,6 +192,7 @@ const AdminNoticeEdit = () => {
           handleChange={handleContentChange}
           fullWidth
         />
+        <div css={noticesContentStyle}>{renderContent(content)}</div>
       </div>
       <div css={noticesDetailMainStyle}>
         <div css={noticesFileStyle}>
@@ -211,7 +255,6 @@ const AdminNoticeEdit = () => {
           handleClick={handleSubmit}
         />
       </div>
-
       <Modal
         id='error-load'
         content={
@@ -268,6 +311,11 @@ const noticesDetailHeaderStyle = css`
   }
 `;
 
+const noticesContentStyle = css`
+  padding-top: 16px;
+  white-space: pre-line;
+`;
+
 const noticesDetailMainStyle = css`
   padding: 40px 0 24px;
 `;
@@ -276,28 +324,6 @@ const noticesFileStyle = css`
   display: flex;
   flex-direction: column;
   gap: 14px;
-
-  .file-title {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: 4px;
-
-    p:first-child {
-      font-weight: ${FONT_WEIGHT.BOLD};
-    }
-
-    span:last-child {
-      margin-left: 8px;
-      font-size: ${FONT_SIZE.TEXT_SM};
-      color: ${COLOR_OPACITY.BLACK_OPACITY30};
-    }
-  }
-
-  .point {
-    color: ${COLOR.POINT};
-    text-align: right;
-  }
 `;
 
 const noticesFileDivStyle = css`
@@ -336,15 +362,8 @@ const iconStyle = css`
 
 const textAreaIconStyle = css`
   display: flex;
-  justify-content: flex-start;
-  margin-bottom: 8px;
-  padding-left: 16px;
   gap: 16px;
-  font-size: 20px;
-
-  svg {
-    font-size: inherit;
-  }
+  margin-bottom: 8px;
 `;
 
 const btnStyle = css`
@@ -354,17 +373,12 @@ const btnStyle = css`
   gap: 16px;
 `;
 
-const inputStyle = css`
-  margin-bottom: 40px;
-`;
-
 const radioBtnStyle = css`
   display: flex;
   gap: 16px;
   margin-top: 12px;
 
   p {
-    transform: translateY(32%);
     font-weight: ${FONT_WEIGHT.BOLD};
   }
 `;
@@ -382,6 +396,10 @@ const modalTextStyle = css`
   text-align: center;
   margin-top: 32px;
   margin-bottom: 24px;
+`;
+
+const inputStyle = css`
+  margin-bottom: 40px;
 `;
 
 export default AdminNoticeEdit;

--- a/src/pages/admin/AdminNoticesDetail.tsx
+++ b/src/pages/admin/AdminNoticesDetail.tsx
@@ -34,6 +34,8 @@ interface NoticesDataProps {
   previousWriteDate?: string;
   nextTitle?: string;
   nextWriteDate?: string;
+  previousId?: string;
+  nextId?: string;
   fileDtoList?: FileDto[];
 }
 
@@ -44,7 +46,6 @@ const AdminNoticesDetail = () => {
   const { noticeId: paramNoticeId } = useParams<{ noticeId: string }>();
   const noticeId = paramNoticeId ? Number(paramNoticeId) : 0;
   const [data, setData] = useState<NoticesDataProps>({ fileDtoList: [] });
-
   const params = { noticeId: String(noticeId) };
   const getNoticeMutation = useGetAdminNotice(params);
 
@@ -129,10 +130,6 @@ const AdminNoticesDetail = () => {
     );
   }
 
-  const handleToggle = () => {
-    setToggleOn((prev) => !prev);
-  };
-
   return (
     <div css={noticesDetailWrapperStyle}>
       <div css={noticesDetailHeaderStyle}>
@@ -178,7 +175,7 @@ const AdminNoticesDetail = () => {
             </div>
             <div className='right-section'>
               <span className='toggle-text'>공개여부</span>
-              <Toggle checked={toggleOn} handleChange={handleToggle} />
+              <Toggle checked={toggleOn} handleChange={() => {}} />
               <p className='hits'>
                 조회수 <span>{data.hits}</span>
               </p>
@@ -186,8 +183,35 @@ const AdminNoticesDetail = () => {
           </div>
         </div>
         <div css={noticesContentStyle}>
-          <p>{data.noticeContent}</p>
+          {data.noticeContent?.split('\n').map((line, index) => {
+            const imageRegex = /!\[image]\((.+)\)/;
+            const match = line.match(imageRegex);
+
+            if (match) {
+              const imageUrl = match[1];
+              return (
+                <img
+                  key={index}
+                  src={imageUrl}
+                  alt='Uploaded Image'
+                  css={css`
+                    max-width: 100%;
+                    height: auto;
+                    margin: 8px 0;
+                  `}
+                />
+              );
+            }
+
+            return (
+              <span key={index}>
+                {line}
+                <br />
+              </span>
+            );
+          })}
         </div>
+
         {data.fileDtoList && data.fileDtoList.length > 0 && (
           <div css={noticesFileStyle}>
             <div className='file-title'>
@@ -230,7 +254,7 @@ const AdminNoticesDetail = () => {
             <div>
               <p>이전</p>
               <span>
-                <Link to={`/notices/${Number(noticeId) - 1}`} css={linkStyle}>
+                <Link to={`/admin/notices/${data.previousId}`} css={linkStyle}>
                   {data.previousTitle}
                 </Link>
               </span>
@@ -243,7 +267,7 @@ const AdminNoticesDetail = () => {
             <div>
               <p>다음</p>
               <p>
-                <Link to={`/notices/${Number(noticeId) + 1}`} css={linkStyle}>
+                <Link to={`/admin/notices/${data.nextId}`} css={linkStyle}>
                   {data.nextTitle}
                 </Link>
               </p>
@@ -270,14 +294,14 @@ const AdminNoticesDetail = () => {
             <div css={modalButtonWrapperStyle}>
               <Button
                 label='아니오'
-                handleClick={() => closeModal('delete-confirm')} // 모달 닫기
+                handleClick={() => closeModal('delete-confirm')}
                 color='primaryOpacity10'
                 border
               />
               <Button
                 label='예'
                 handleClick={() => {
-                  closeModal('delete-confirm'); // 모달 닫기
+                  closeModal('delete-confirm');
                   deleteMutation.mutate(String(noticeId), {
                     onSuccess: () => {
                       navigate(PATH.ADMIN_NOTICES);
@@ -366,6 +390,8 @@ const noticesTitleStyle = css`
 const noticesContentStyle = css`
   padding: 24px 24px 64px;
   min-height: 280px;
+  white-space: pre-line;
+  word-break: break-word;
 `;
 const noticesFileStyle = css`
   display: flex;

--- a/src/pages/mypage/ProfileEdit.tsx
+++ b/src/pages/mypage/ProfileEdit.tsx
@@ -77,10 +77,12 @@ const ProfileEdit: React.FC = () => {
   };
 
   const handleComplete = () => {
+    const isSameNickname = nickname.trim() === storeNickname?.trim();
+
     if (
       nicknameStatus === 'warn' ||
       phoneStatus === 'warn' ||
-      !isNicknameChecked
+      (!isSameNickname && !isNicknameChecked)
     ) {
       openModal('update-confirm');
       return;
@@ -94,7 +96,7 @@ const ProfileEdit: React.FC = () => {
         userId,
         phoneNumber,
         nickname,
-        nicknameDuplCheck: true,
+        nicknameDuplCheck: !isSameNickname,
       })
     );
 

--- a/src/pages/mypage/QnaDetail.tsx
+++ b/src/pages/mypage/QnaDetail.tsx
@@ -3,6 +3,7 @@ import SubdirectoryArrowRightIcon from '@mui/icons-material/SubdirectoryArrowRig
 import { Link, useNavigate, useParams } from 'react-router-dom';
 import Button from '@/components/Button';
 import Modal from '@/components/Modal';
+import Tag from '@/components/Tag';
 import { COLOR, COLOR_OPACITY } from '@/constants/color';
 import { FONT_SIZE, FONT_WEIGHT } from '@/constants/font';
 import { PATH } from '@/constants/path';
@@ -27,7 +28,10 @@ const QnaDetail = () => {
   const userInquiryId = paramUserId ? Number(paramUserId) : 0;
   const { qnaId: paramQnaId } = useParams<{ qnaId: string }>();
   const qnaInquiryId = paramQnaId ? Number(paramQnaId) : 0;
-
+  const { previousId: paramPreviousId } = useParams<{ previousId: string }>();
+  const previousId = paramPreviousId ? Number(paramPreviousId) : 0;
+  const { nextId: paramNextId } = useParams<{ nextId: string }>();
+  const nextId = paramNextId ? Number(paramNextId) : 0;
   const deleteMutation = useDeleteInquiry();
 
   const userQuery = useGetInquiryDetailUser(
@@ -147,10 +151,23 @@ const QnaDetail = () => {
             {qnaData.strategyName ? (
               <>
                 <div css={tagsAndTitleStyle}>
-                  <span>
-                    <img src={qnaData.methodIconPath} alt='' css={iconStyle} />
-                  </span>
-                  <div css={strategyTextStyle}>{qnaData.strategyName}</div>
+                  <div css={tagContainerStyle}>
+                    {qnaData.methodIconPath && (
+                      <Tag src={qnaData.methodIconPath} alt='method icon' />
+                    )}
+                    {Array.isArray(qnaData.stockList?.stockIconPath) &&
+                      qnaData.stockList?.stockIconPath.map(
+                        (stock: string, idx: number) => (
+                          <Tag key={idx} src={stock} alt='stock icon' />
+                        )
+                      )}
+                  </div>
+                  <Link
+                    to={PATH.STRATEGIES_DETAIL(qnaData.strategyId)}
+                    css={strategyTextStyle}
+                  >
+                    {qnaData.strategyName}
+                  </Link>
                 </div>
                 <div css={profileStyle}>
                   <img
@@ -158,7 +175,6 @@ const QnaDetail = () => {
                     alt='method icon'
                     css={profileImgStyle}
                   />
-
                   <span css={nicknameStyle}>{qnaData.traderNickname}</span>
                 </div>
               </>
@@ -187,9 +203,9 @@ const QnaDetail = () => {
                     <div css={answerProfileStyle}>
                       <span>
                         <img
-                          src={qnaData.methodIconPath}
+                          src={qnaData.traderProfileImagePath}
                           alt=''
-                          css={iconStyle}
+                          css={profileImgStyle}
                         />
                       </span>
                       <span css={nicknameStyle}>{qnaData.traderNickname}</span>
@@ -206,10 +222,7 @@ const QnaDetail = () => {
               <div css={listItemStyle}>
                 <span css={stepperStyle}>이전</span>
                 <Link
-                  to={PATH.MYPAGE_QNA_DETAIL(
-                    String(userInquiryId),
-                    String(qnaInquiryId - 1)
-                  )}
+                  to={`/mypage/${qnaData.userId}/qna/${qnaData.previousId}`}
                   css={listItemTilteStyle}
                 >
                   {qnaData.previousTitle}
@@ -220,10 +233,7 @@ const QnaDetail = () => {
               <div css={listItemStyle}>
                 <span css={stepperStyle}>다음</span>
                 <Link
-                  to={PATH.MYPAGE_QNA_DETAIL(
-                    String(userInquiryId),
-                    String(qnaInquiryId + 1)
-                  )}
+                  to={`/mypage/${qnaData.userId}/qna/${qnaData.nextId}`}
                   css={listItemTilteStyle}
                 >
                   {qnaData.nextTitle}
@@ -247,7 +257,7 @@ const QnaDetail = () => {
             content={
               <div css={modalContentStyle}>
                 <p css={modalTextStyle}>
-                  답변이 존재할 시 새로운 답변을 달 수 없습니다.
+                  답변이 존재할 시 문의를 수정할 수 없습니다.
                 </p>
               </div>
             }
@@ -384,15 +394,18 @@ const tagsAndTitleStyle = css`
   flex-direction: column;
 `;
 
-// const tagStyle = css`
-//   display: flex;
-//   gap: 8px;
-// `;
-
 const strategyTextStyle = css`
   margin-top: 16px;
   font-size: ${FONT_SIZE.TEXT_MD};
   font-weight: ${FONT_WEIGHT.REGULAR};
+  text-decoration: none;
+  font-color: ${COLOR.TEXT_BLACK};
+`;
+
+const tagContainerStyle = css`
+  display: flex;
+  align-items: center;
+  gap: 4px;
 `;
 
 const profileStyle = css`

--- a/src/pages/mypage/QnaList.tsx
+++ b/src/pages/mypage/QnaList.tsx
@@ -4,6 +4,7 @@ import { Link, useParams } from 'react-router-dom';
 import Pagination from '@/components/Pagination';
 import SelectBox from '@/components/SelectBox';
 import Table, { ColumnProps } from '@/components/Table';
+import Tag from '@/components/Tag';
 import { COLOR, COLOR_OPACITY } from '@/constants/color';
 import { FONT_SIZE, FONT_WEIGHT } from '@/constants/font';
 import { PATH } from '@/constants/path';
@@ -21,7 +22,10 @@ interface QnaListDataProps {
   strategyName: string;
   inquiryRegistrationDate: string;
   inquiryStatus: string;
-  methodIconPath: string;
+  methodIconPath?: string;
+  stockList?: {
+    stockIconPath?: string[];
+  };
 }
 
 const strategyOptions = [
@@ -84,7 +88,7 @@ const QnaList = () => {
     {
       key: 'inquiryTitle',
       header: '제목',
-      render: (value, item) => (
+      render: (_, item) => (
         <div css={questionContainerStyle}>
           <div css={questionTitleStyle}>
             <Link
@@ -94,7 +98,7 @@ const QnaList = () => {
               )}
               css={linkStyle}
             >
-              {value}
+              {item.inquiryTitle}
             </Link>
           </div>
         </div>
@@ -103,19 +107,16 @@ const QnaList = () => {
     {
       key: 'strategyName',
       header: '전략명',
-      render: (value, item) => (
+      render: (_, item) => (
         <div css={strategyStyle}>
-          {item.methodIconPath !== null &&
-            item.methodIconPath !== undefined && (
-              <span>
-                <img
-                  src={item.methodIconPath}
-                  alt='method icon'
-                  css={iconStyle}
-                />
-              </span>
-            )}
-          <span>{value}</span>
+          <div className='tag'>
+            {item.methodIconPath && <Tag src={item.methodIconPath} alt='tag' />}
+            {Array.isArray(item?.stockList?.stockIconPath) &&
+              item.stockList.stockIconPath.map((stock: string, index: number) => (
+                <Tag key={index} src={stock || ''} alt='tag' />
+              ))}
+          </div>
+          <span>{item.strategyName}</span>
         </div>
       ),
     },
@@ -128,9 +129,9 @@ const QnaList = () => {
     {
       key: 'inquiryStatus',
       header: '진행상태',
-      render: (value) => (
-        <span css={value === 'closed' ? successStyle : waitingStyle}>
-          {statusMap[value] || ''}
+      render: (_, item) => (
+        <span css={item.inquiryStatus === 'closed' ? successStyle : waitingStyle}>
+          {statusMap[item.inquiryStatus] || ''}
         </span>
       ),
     },

--- a/src/stores/useAuthStore.ts
+++ b/src/stores/useAuthStore.ts
@@ -14,6 +14,8 @@ interface AuthConfig {
   profileImage: string | null;
   totalFollowerCount: number;
   totalStrategyCount: number;
+  receiveInfoConsent: boolean;
+  receiveMarketingConsent: boolean;
 }
 
 interface AuthStateProps extends AuthConfig {
@@ -35,6 +37,8 @@ const resetState = (set: Function) => {
     profileImage: null,
     totalFollowerCount: 0,
     totalStrategyCount: 0,
+    receiveInfoConsent: false,
+    receiveMarketingConsent: false,
     isAuthInitialized: true,
   });
   localStorage.removeItem('token');
@@ -52,6 +56,8 @@ const updateState = (set: Function, authData: AuthConfig) => {
     profileImage: authData.profileImage,
     totalFollowerCount: authData.totalFollowerCount,
     totalStrategyCount: authData.totalStrategyCount,
+    receiveInfoConsent: authData.receiveInfoConsent,
+    receiveMarketingConsent: authData.receiveMarketingConsent,
     isAuthInitialized: true,
   });
 };
@@ -67,6 +73,8 @@ const useAuthStore = create<AuthStateProps>((set) => ({
   profileImage: null,
   totalFollowerCount: 0,
   totalStrategyCount: 0,
+  receiveInfoConsent: false,
+  receiveMarketingConsent: false,
   isAuthInitialized: false,
 
   setAuthState: (authData) => updateState(set, authData),


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

담당파트 수정했습니다.

## 📋 작업 내용

- [x] 공지사항 목록 필터 가능하게 수정
- [x] 공지사항 목록 검색어 입력 시 자동 필터링이 아닌 버튼 클릭시 검색 가능하도록 변경
- [x] 마이페이지 진입시 간헐적 에러 난다는 거 확인 후 수정
- [x] 공지사항 목록에서 리스트 삭제 후 체크박스 남아있는거 수정
- [x] 마이페이지 정보수신변경 페이지에 현재 상태 조회되도록 수정 (백앤드 작업 필요)
- [x] 마이페이지 계정정보변경 때 프로필, 휴대번호를 개별적으로 가능하도록 수정 (현재 닉네임중복확인떄문에 닉네임변경해야만함)
- [x] 마이페이지 나의상담(문의) 상세페이지에서 전략을 클릭 시 해당 전략으로 이동 시키도록
- [x] 공지사항 등록 시 이미지 삽입 가능하도록
- [x] 공지사항 수정 시 파일 추가 에러 수정 (백엔드 수정중)
- [x] 자잘

## 📸 스크린샷 (선택 사항)

![z-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/c70b4950-8ee6-486f-9f69-07b43292da77)

## 📄 기타
ㅋㅋ

