### PR TITLE
[fix] 담당 파트 수정(대영)

### DIFF
--- a/src/hooks/useMyStrategyEdit.ts
+++ b/src/hooks/useMyStrategyEdit.ts
@@ -105,7 +105,7 @@ const useMyStrategyEdit = () => {
   const { mutate: deleteAccountMutate } = useDeleteMyStrateAccount();
 
   useEffect(() => {
-    if (strategyInfoIsError) navigate(PATH.NOT_FOUND);
+    if (strategyInfoIsError) navigate(PATH.MYPAGE);
 
     if (roleCode === 'TRADER' && methodsAndStocks && strategyInfo) {
       setMethodOptions(

--- a/src/hooks/useStrategyApi.ts
+++ b/src/hooks/useStrategyApi.ts
@@ -540,6 +540,7 @@ export const useGetStrategyInfo = (strategyId: string) => {
       queryKey: ['strategyInfo'],
       queryFn: () => getStrategyInfo(strategyId),
       refetchOnWindowFocus: false,
+      retry: 0,
     }
   );
 
@@ -685,17 +686,19 @@ export const useChangePrivateStrategy = () =>
   });
 
 export const useGetMyStrategyInfo = (strategyId: string) => {
-  const { data, isSuccess, refetch } = useQuery<GetStrategyInfoResponse, Error>(
-    {
-      queryKey: ['myStrategyInfo'],
-      queryFn: () => getMyStrategyInfo(strategyId),
-      refetchOnWindowFocus: false,
-    }
-  );
+  const { data, isSuccess, isError, refetch } = useQuery<
+    GetStrategyInfoResponse,
+    Error
+  >({
+    queryKey: ['myStrategyInfo'],
+    queryFn: () => getMyStrategyInfo(strategyId),
+    refetchOnWindowFocus: false,
+    retry: 0,
+  });
 
   return {
     data: isSuccess && data?.code === 200 ? data.data : undefined,
-    isError: isSuccess && data?.code !== 200,
+    isError,
     refetch,
   };
 };

--- a/src/hooks/useStrategyApi.ts
+++ b/src/hooks/useStrategyApi.ts
@@ -535,18 +535,23 @@ export const useDeleteTraderAddStrategyList = () => {
 };
 
 export const useGetStrategyInfo = (strategyId: string) => {
-  const { data, isSuccess, refetch } = useQuery<GetStrategyInfoResponse, Error>(
-    {
-      queryKey: ['strategyInfo'],
-      queryFn: () => getStrategyInfo(strategyId),
-      refetchOnWindowFocus: false,
-      retry: 0,
-    }
-  );
+  const {
+    data,
+    isSuccess,
+    isError: queryError,
+    refetch,
+  } = useQuery<GetStrategyInfoResponse, Error>({
+    queryKey: ['strategyInfo'],
+    queryFn: () => getStrategyInfo(strategyId),
+    refetchOnWindowFocus: false,
+    retry: 0,
+  });
+
+  const isResponseError = isSuccess && data?.code !== 200;
 
   return {
     data: isSuccess && data?.code === 200 ? data.data : undefined,
-    isError: isSuccess && data?.code !== 200,
+    isError: queryError || isResponseError,
     refetch,
   };
 };

--- a/src/layouts/Layout.tsx
+++ b/src/layouts/Layout.tsx
@@ -1,14 +1,25 @@
 import { useEffect } from 'react';
 import { css } from '@emotion/react';
-import { Outlet } from 'react-router-dom';
+import { Outlet, useLocation } from 'react-router-dom';
 import ToTopButton from '@/components/ToTopButton';
 import Footer from '@/layouts/Footer';
 import Header from '@/layouts/Header';
+import useAuthStore from '@/stores/useAuthStore';
 
 const Layout = () => {
+  const location = useLocation();
+  const { resetAuthState } = useAuthStore();
+
   useEffect(() => {
     window.scrollTo(0, 0);
   }, []);
+
+  useEffect(() => {
+    const token = localStorage.getItem('token');
+    if (!token) {
+      resetAuthState();
+    }
+  }, [location, resetAuthState]);
 
   return (
     <div css={containerStyle}>

--- a/src/layouts/StrategyDetailLayout.tsx
+++ b/src/layouts/StrategyDetailLayout.tsx
@@ -156,7 +156,7 @@ const StrategyDetailLayout = () => {
   }, [strategyAnalysis, graphOption1, graphOption2]);
 
   useEffect(() => {
-    if (strategyInfoIsError) navigate(PATH.NOT_FOUND);
+    if (strategyInfoIsError) navigate(PATH.STRATEGIES_LIST);
   }, [strategyInfo, strategyInfoIsError]);
 
   useEffect(() => {

--- a/src/layouts/StrategyDetailLayout.tsx
+++ b/src/layouts/StrategyDetailLayout.tsx
@@ -587,7 +587,9 @@ const StrategyDetailLayout = () => {
                                 typeof value === 'number'
                                   ? value < 0
                                     ? COLOR.PRIMARY400
-                                    : COLOR.POINT
+                                    : value === 0
+                                      ? 'inherit'
+                                      : COLOR.POINT
                                   : 'inherit',
                             }}
                           >

--- a/src/layouts/StrategyDetailLayout.tsx
+++ b/src/layouts/StrategyDetailLayout.tsx
@@ -118,8 +118,8 @@ const StrategyDetailLayout = () => {
       PATH.STRATEGIES_DETAIL_ACCOUNT(strategyId),
     ];
 
-    navigate(pathArr[currentTab]);
-  }, [currentTab, navigate]);
+    navigate(pathArr[currentTab], { replace: true });
+  }, [currentTab]);
 
   useEffect(() => {
     if (strategyAnalysis) {

--- a/src/pages/StrategyAdd.tsx
+++ b/src/pages/StrategyAdd.tsx
@@ -74,14 +74,16 @@ const StrategyAdd = () => {
           </div>
           <div className='form-item'>
             <span>운용종목</span>
-            {stockOptions.map((option: { label: string; value: string }) => (
-              <Checkbox
-                key={option.value}
-                checked={stocks.includes(option.value)}
-                label={option.label}
-                handleChange={() => handleCheckboxChange(option.value)}
-              />
-            ))}
+            <div className='stock-box'>
+              {stockOptions.map((option: { label: string; value: string }) => (
+                <Checkbox
+                  key={option.value}
+                  checked={stocks.includes(option.value)}
+                  label={option.label}
+                  handleChange={() => handleCheckboxChange(option.value)}
+                />
+              ))}
+            </div>
           </div>
           <div className='form-item form-item-top'>
             <span>
@@ -294,6 +296,12 @@ const addContentBoxStyle = css`
           font-size: ${FONT_SIZE.TEXT_SM};
           font-weight: ${FONT_WEIGHT.REGULAR};
         }
+      }
+
+      .stock-box {
+        display: flex;
+        flex-wrap: wrap;
+        width: 1000px;
       }
 
       .file-box {

--- a/src/pages/mypage/MyStrategyEdit.tsx
+++ b/src/pages/mypage/MyStrategyEdit.tsx
@@ -143,14 +143,16 @@ const MyStrategyEdit = () => {
           </div>
           <div className='form-item'>
             <span>운용종목</span>
-            {stockOptions.map((option: { label: string; value: string }) => (
-              <Checkbox
-                key={option.value}
-                checked={stocks.includes(option.value)}
-                label={option.label}
-                handleChange={() => handleCheckboxChange(option.value)}
-              />
-            ))}
+            <div className='stock-box'>
+              {stockOptions.map((option: { label: string; value: string }) => (
+                <Checkbox
+                  key={option.value}
+                  checked={stocks.includes(option.value)}
+                  label={option.label}
+                  handleChange={() => handleCheckboxChange(option.value)}
+                />
+              ))}
+            </div>
           </div>
           <div className='form-item form-item-top'>
             <span>
@@ -1047,6 +1049,12 @@ const formBoxStyle = css`
         }
       }
 
+      .stock-box {
+        display: flex;
+        flex-wrap: wrap;
+        width: 1000px;
+      }
+
       .file-box {
         display: flex;
         gap: 16px;
@@ -1121,7 +1129,9 @@ const onlyViewBoxStyle = css`
 
       .options {
         display: flex;
-        gap: 8px;
+        flex-wrap: wrap;
+        width: 1000px;
+        gap: 16px;
       }
 
       .file-box {

--- a/src/stores/useAuthStore.ts
+++ b/src/stores/useAuthStore.ts
@@ -14,6 +14,8 @@ interface AuthConfig {
   profileImage: string | null;
   totalFollowerCount: number;
   totalStrategyCount: number;
+  receiveInfoConsent: boolean;
+  receiveMarketingConsent: boolean;
 }
 
 interface AuthStateProps extends AuthConfig {
@@ -35,6 +37,8 @@ const resetState = (set: Function) => {
     profileImage: null,
     totalFollowerCount: 0,
     totalStrategyCount: 0,
+    receiveInfoConsent: false,
+    receiveMarketingConsent: false,
     isAuthInitialized: true,
   });
   localStorage.removeItem('token');
@@ -52,6 +56,8 @@ const updateState = (set: Function, authData: AuthConfig) => {
     profileImage: authData.profileImage,
     totalFollowerCount: authData.totalFollowerCount,
     totalStrategyCount: authData.totalStrategyCount,
+    receiveInfoConsent: authData.receiveInfoConsent,
+    receiveMarketingConsent: authData.receiveMarketingConsent,
     isAuthInitialized: true,
   });
 };
@@ -67,6 +73,8 @@ const useAuthStore = create<AuthStateProps>((set) => ({
   profileImage: null,
   totalFollowerCount: 0,
   totalStrategyCount: 0,
+  receiveInfoConsent: false,
+  receiveMarketingConsent: false,
   isAuthInitialized: false,
 
   setAuthState: (authData) => updateState(set, authData),


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

담당 파트 수정(대영)

## 📋 작업 내용

- 본인의 전략 수정 페이지만 접근 가능하도록 처리
- 토큰이 존재하지 않을 경우 라우팅 시 AuthStore 초기화 처리
- 운용 종목 11개 종목 최신화 및 아이콘 등록
- 전략 등록/수정 페이지 운용 종목 줄바꿈 CSS 처리

## 📸 스크린샷 (선택 사항)

수정된 화면 또는 기능을 시연할 수 있는 스크린샷을 첨부할 수 있습니다.

## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.
