### PR TITLE
[fix] 담당 파트 수정(혜지)

### DIFF
--- a/src/api/adminApi.ts
+++ b/src/api/adminApi.ts
@@ -426,8 +426,19 @@ export const deleteAdminMethods = async (ids: number[]) => {
 };
 
 // 관리자 문의 상세조회 API
-export const getAdminInquiryDetail = async (qnaId: number) => {
-  const response = await axiosInstance.get(`/v1/admin/qna/${qnaId}`);
+export const getAdminInquiryDetail = async (
+  qnaId: number,
+  closed: string,
+  searchType: string,
+  searchText: string
+) => {
+  const response = await axiosInstance.get(`/v1/admin/qna/${qnaId}`, {
+    params: {
+      closed,
+      searchType,
+      searchText,
+    },
+  });
 
   return response.data;
 };

--- a/src/components/StrategyFilter.tsx
+++ b/src/components/StrategyFilter.tsx
@@ -342,7 +342,7 @@ const filterContentStyle = css`
 
     .filter-label {
       display: block;
-      width: 80px;
+      min-width: 80px;
       font-weight: ${FONT_WEIGHT.BOLD};
       color: ${COLOR.BLACK};
     }

--- a/src/hooks/useAdminApi.ts
+++ b/src/hooks/useAdminApi.ts
@@ -179,10 +179,15 @@ export const useDeleteInquiryList = () => {
 };
 
 // 관리자 문의 상세조회
-export const useGetAdminInquiryDetail = (qnaId: number) =>
+export const useGetAdminInquiryDetail = (
+  qnaId: number,
+  closed: string,
+  searchType: string,
+  searchText: string
+) =>
   useQuery({
-    queryKey: ['adminInquiryDetail', qnaId],
-    queryFn: () => getAdminInquiryDetail(qnaId),
+    queryKey: ['adminInquiryDetail', qnaId, closed, searchType, searchText],
+    queryFn: () => getAdminInquiryDetail(qnaId, closed, searchType, searchText),
   });
 
 // 관리자 문의 특정 삭제 API

--- a/src/pages/SignIn.tsx
+++ b/src/pages/SignIn.tsx
@@ -35,13 +35,15 @@ const SignIn = () => {
       setter('');
 
   const validateEmail = (value: string) => {
-    setEmail(value);
-    setEmailError(!emailRegEx.test(value));
+    const trimmedValue = value.trim();
+    setEmail(trimmedValue);
+    setEmailError(!emailRegEx.test(trimmedValue));
   };
 
   const validatePassword = (value: string) => {
-    setPassword(value);
-    setPasswordError(!passwordRegEx.test(value));
+    const trimmedValue = value.trim();
+    setPassword(trimmedValue);
+    setPasswordError(!passwordRegEx.test(trimmedValue));
   };
 
   const handleSignIn = () => {

--- a/src/pages/StrategyList.tsx
+++ b/src/pages/StrategyList.tsx
@@ -8,6 +8,8 @@ import {
 import { css } from '@emotion/react';
 import SearchOutlinedIcon from '@mui/icons-material/SearchOutlined';
 import { useNavigate } from 'react-router-dom';
+import dayIcon from '@/assets/images/day-icon.png';
+import positionIcon from '@/assets/images/position-icon.png';
 import Button from '@/components/Button';
 import Modal from '@/components/Modal';
 import Pagination from '@/components/Pagination';
@@ -561,12 +563,18 @@ export const StrategyList = () => {
         <div css={tagStyle}>
           <div className='tag'>
             <Tag src={item?.methodIconPath || ''} alt='tag' />
-            {item?.stockList?.stockIconPath &&
-              item?.stockList?.stockIconPath.map(
-                (stock: string, index: number) => (
+            <Tag src={item?.cycle === 'D' ? dayIcon : positionIcon} />
+            {currentTab === 1
+              ? item?.stockIconPath &&
+                item?.stockIconPath.map((stock: string, index: number) => (
                   <Tag key={index} src={stock} alt='tag' />
-                )
-              )}
+                ))
+              : item?.stockList?.stockIconPath &&
+                item.stockList.stockIconPath.map(
+                  (stock: string, index: number) => (
+                    <Tag key={index} src={stock} alt='tag' />
+                  )
+                )}
           </div>
           {item.name}
         </div>

--- a/src/pages/TraderStrategyList.tsx
+++ b/src/pages/TraderStrategyList.tsx
@@ -3,6 +3,8 @@ import { css } from '@emotion/react';
 import ContentCopyOutlinedIcon from '@mui/icons-material/ContentCopyOutlined';
 import FavoriteBorderOutlinedIcon from '@mui/icons-material/FavoriteBorderOutlined';
 import { useNavigate } from 'react-router-dom';
+import dayIcon from '@/assets/images/day-icon.png';
+import positionIcon from '@/assets/images/position-icon.png';
 import Button from '@/components/Button';
 import Modal from '@/components/Modal';
 import Pagination from '@/components/Pagination';
@@ -372,6 +374,7 @@ const TraderStrategyList = () => {
         <div css={tagStyle}>
           <div className='tag'>
             <Tag src={item?.methodIconPath || ''} alt='tag' />
+            <Tag src={item?.cycle === 'D' ? dayIcon : positionIcon} />
             {item?.stockList?.stockIconPath &&
               item?.stockList?.stockIconPath.map(
                 (stock: string, index: number) => (

--- a/src/pages/TraderStrategyList.tsx
+++ b/src/pages/TraderStrategyList.tsx
@@ -551,11 +551,15 @@ const TraderStrategyList = () => {
           <h5>트레이더 전략정보</h5>
         </div>
         <Table data={tableData || []} columns={columns} />
-        <Pagination
-          totalPage={totalPage}
-          currentPage={currentPage}
-          handlePageChange={setCurrentPage}
-        />
+        {tableData?.length > 0 ? (
+          <Pagination
+            totalPage={totalPage}
+            currentPage={currentPage}
+            handlePageChange={setCurrentPage}
+          />
+        ) : (
+          <span css={emptyContents}>트레이더의 전략 정보가 없습니다.</span>
+        )}
       </section>
     </div>
   );
@@ -645,6 +649,37 @@ const tableWrapperStyle = css`
   flex-direction: column;
   gap: 29px;
 
+  table > thead > tr > th {
+    &:nth-of-type(1) {
+      width: 80px;
+    }
+    &:nth-of-type(2) {
+      width: 202px;
+    }
+    &:nth-of-type(3) {
+      width: 280px;
+    }
+    &:nth-of-type(4) {
+      width: 120px;
+    }
+    &:nth-of-type(5) {
+      width: 120px;
+    }
+    &:nth-of-type(6) {
+      width: 120px;
+    }
+    &:nth-of-type(7) {
+      width: 120px;
+    }
+  }
+
+  table > tbody > tr > td {
+    &:nth-of-type(2) div {
+      display: flex;
+      justify-content: center;
+    }
+  }
+
   .title-area {
     position: relative;
     padding: 28px 0;
@@ -724,6 +759,13 @@ const addInteresmodalStyle = css`
 
 const fontStyle = css`
   font-weight: ${FONT_WEIGHT.BOLD};
+`;
+
+const emptyContents = css`
+  padding: 32px;
+  border-radius: 4px;
+  background: ${COLOR.GRAY100};
+  text-align: center;
 `;
 
 export default TraderStrategyList;

--- a/src/pages/admin/AdminQna.tsx
+++ b/src/pages/admin/AdminQna.tsx
@@ -18,7 +18,7 @@ import { PATH } from '@/constants/path';
 import { useDeleteInquiryList, useGetInquiryList } from '@/hooks/useAdminApi';
 import useModalStore from '@/stores/useModalStore';
 import { useTableStore } from '@/stores/useTableStore';
-import { extractDate } from '@/utils/dataUtils';
+import { formatYearMonthFromDateTime } from '@/utils/dataUtils';
 
 interface AdminQnaDataProps {
   ranking?: number;
@@ -199,7 +199,7 @@ const AdminQna = () => {
 
   useEffect(() => {
     inquiryListDataRefetch();
-  }, [currentPage]);
+  }, [currentPage, inquiryListDataRefetch]);
 
   const columns: ColumnProps<AdminQnaDataProps>[] = [
     {
@@ -239,7 +239,7 @@ const AdminQna = () => {
       key: 'inquiryRegistrationDate',
       header: '문의날짜',
       render: (_, item) => (
-        <span>{extractDate(item.inquiryRegistrationDate)}</span>
+        <span>{formatYearMonthFromDateTime(item.inquiryRegistrationDate)}</span>
       ),
     },
     {
@@ -267,7 +267,13 @@ const AdminQna = () => {
           border={true}
           width={80}
           handleClick={() =>
-            navigate(PATH.ADMIN_QNA_DETAIL(String(item.inquiryId)))
+            navigate(PATH.ADMIN_QNA_DETAIL(String(item.inquiryId)), {
+              state: {
+                closed: item.inquiryStatus,
+                searchType: selectiedOption,
+                searchText,
+              },
+            })
           }
         />
       ),
@@ -304,7 +310,7 @@ const AdminQna = () => {
           value={value}
           handleKeyDown={(e) => {
             if (e.key === 'Enter') {
-              setSearchText(value);
+              setSearchText(value.trim());
             }
           }}
           handleChange={(e) => setValue(e.target.value)}

--- a/src/pages/admin/AdminQna.tsx
+++ b/src/pages/admin/AdminQna.tsx
@@ -1,6 +1,8 @@
 import { Dispatch, SetStateAction, useEffect, useState } from 'react';
 import { css } from '@emotion/react';
 import { useNavigate } from 'react-router-dom';
+import dayIcon from '@/assets/images/day-icon.png';
+import positionIcon from '@/assets/images/position-icon.png';
 import Button from '@/components/Button';
 import Loading from '@/components/Loading';
 import Modal from '@/components/Modal';
@@ -141,7 +143,12 @@ const AdminQna = () => {
     data: InquiryListData,
     refetch: inquiryListDataRefetch,
     isLoading,
-  } = useGetInquiryList(0, getTabValue(tab), selectiedOption, searchText);
+  } = useGetInquiryList(
+    currentPage,
+    getTabValue(tab),
+    selectiedOption,
+    searchText
+  );
 
   const handleOptionChange = (value: string) => {
     setSelectedOption(value);
@@ -190,6 +197,10 @@ const AdminQna = () => {
     setCurrentPage(0);
   }, [searchText]);
 
+  useEffect(() => {
+    inquiryListDataRefetch();
+  }, [currentPage]);
+
   const columns: ColumnProps<AdminQnaDataProps>[] = [
     {
       key: 'ranking',
@@ -209,11 +220,14 @@ const AdminQna = () => {
       render: (_, item) => (
         <div css={tagStyle}>
           <div className='tag'>
-            <Tag src={item?.methodIconPath || ''} />
+            {item?.methodIconPath && (
+              <Tag src={item.methodIconPath} alt='methodIcon' />
+            )}
+            <Tag src={item?.cycle === 'D' ? dayIcon : positionIcon} />
             {item?.stockList?.stockIconPath &&
               item?.stockList?.stockIconPath.map(
                 (stock: string, index: number) => (
-                  <Tag key={index} src={stock || ''} alt='tag' />
+                  <Tag key={index} src={stock || ''} alt='stockIcon' />
                 )
               )}
           </div>
@@ -339,7 +353,7 @@ const AdminQna = () => {
             <Pagination
               totalPage={totalPage}
               currentPage={currentPage}
-              handlePageChange={setCurrentPage}
+              handlePageChange={(newPage) => setCurrentPage(newPage)}
             />
           </div>
         ) : (

--- a/src/pages/admin/AdminQnaDetail.tsx
+++ b/src/pages/admin/AdminQnaDetail.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 import { css } from '@emotion/react';
 import SubdirectoryArrowRightOutlinedIcon from '@mui/icons-material/SubdirectoryArrowRightOutlined';
-import { Link, useLocation, useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 import dayIcon from '@/assets/images/day-icon.png';
 import positionIcon from '@/assets/images/position-icon.png';
 import Button from '@/components/Button';
@@ -16,7 +16,7 @@ import {
   useGetAdminInquiryDetail,
 } from '@/hooks/useAdminApi';
 import useModalStore from '@/stores/useModalStore';
-import { extractDate } from '@/utils/dataUtils';
+import { formatYearMonthFromDateTime } from '@/utils/dataUtils';
 
 interface AdminQnaDetailDataProps {
   answerContent: string;
@@ -110,17 +110,22 @@ const DelModal = ({
 
 const AdminQnaDetail = () => {
   const navigate = useNavigate();
-  const location = useLocation();
   const deleteModal = useModalStore();
+  const location = useLocation();
+  const { state } = location;
+
   const [qnaId, setQnaId] = useState(1);
+  const closed = state?.closed;
+  const searchType = state?.searchType;
+  const searchText = state?.searchText;
 
   const [data, setData] = useState<AdminQnaDetailDataProps>();
 
   const { data: inquiryDetailData, refetch: inquiryDetailDataRefetch } =
-    useGetAdminInquiryDetail(qnaId);
+    useGetAdminInquiryDetail(qnaId, closed, searchType, searchText);
 
   useEffect(() => {
-    const urlNumber = Number(window.location.pathname.split('/').pop()) || null;
+    const urlNumber = Number(window.location.pathname.split('/').pop());
     if (urlNumber && urlNumber !== qnaId) {
       setQnaId(urlNumber);
     }
@@ -153,7 +158,11 @@ const AdminQnaDetail = () => {
           <div className='info'>
             <div>
               <p>작성일</p>
-              <p>{data?.inquiryRegistrationDate}</p>
+              <p>
+                {formatYearMonthFromDateTime(
+                  inquiryDetailData?.data?.inquiryRegistrationDate || ''
+                )}
+              </p>
             </div>
             <div>
               <p>작성자</p>
@@ -198,7 +207,12 @@ const AdminQnaDetail = () => {
             </div>
             <div className='info'>
               <p>작성일</p>
-              <p>{extractDate(data?.answerRegistrationDate || '')}</p>
+              <p>
+                {inquiryDetailData?.data?.answerRegistrationDate &&
+                  formatYearMonthFromDateTime(
+                    inquiryDetailData?.data?.answerRegistrationDate
+                  )}
+              </p>
             </div>
           </div>
           <div className='profile'>
@@ -211,20 +225,40 @@ const AdminQnaDetail = () => {
         </div>
       </div>
       <div css={adminQnaNavStyle}>
-        <Link className='back-qna' to={`/admin/qna/${data?.previousId}`}>
-          <div>
-            <p>이전</p>
-            <p>{data?.previousTitle}</p>
-          </div>
-          <p>{extractDate(data?.previousWriteDate || '')}</p>
-        </Link>
-        <Link to={`/admin/qna/${data?.nextId}`} className='next-qna'>
-          <div>
-            <p>다음</p>
-            <p>{data?.nextTitle}</p>
-          </div>
-          <p>{extractDate(data?.nextWriteDate || '')}</p>
-        </Link>
+        {data?.previousId && (
+          <button
+            className='back-qna '
+            onClick={() => {
+              if (data?.previousId) {
+                setQnaId(data.previousId);
+                navigate(`/admin/qna/${data.previousId}`);
+              }
+            }}
+          >
+            <div>
+              <p>이전</p>
+              <p>{data?.previousTitle}</p>
+            </div>
+            <p>{formatYearMonthFromDateTime(data?.previousWriteDate || '')}</p>
+          </button>
+        )}
+        {data?.nextId && (
+          <button
+            className='next-qna'
+            onClick={() => {
+              if (data?.nextId) {
+                setQnaId(data.nextId);
+                navigate(`/admin/qna/${data.nextId}`);
+              }
+            }}
+          >
+            <div>
+              <p>다음</p>
+              <p>{data?.nextTitle}</p>
+            </div>
+            <p>{formatYearMonthFromDateTime(data?.nextWriteDate || '')}</p>
+          </button>
+        )}
       </div>
       <div css={buttonStyle}>
         <Button
@@ -379,9 +413,15 @@ const adminQnaNavStyle = css`
     align-items: center;
     padding: 24px;
     height: 64px;
+    border: 0;
     border-bottom: 1px solid ${COLOR_OPACITY.BLACK_OPACITY30};
+    background-color: transparent;
     text-decoration: none;
     color: inherit;
+
+    &:hover {
+      cursor: pointer;
+    }
 
     div {
       display: flex;
@@ -400,9 +440,15 @@ const adminQnaNavStyle = css`
     align-items: center;
     padding: 24px;
     height: 64px;
+    border: 0;
     border-bottom: 1px solid ${COLOR_OPACITY.BLACK_OPACITY30};
+    background-color: transparent;
     text-decoration: none;
     color: inherit;
+
+    &:hover {
+      cursor: pointer;
+    }
 
     div {
       display: flex;

--- a/src/pages/admin/AdminQnaDetail.tsx
+++ b/src/pages/admin/AdminQnaDetail.tsx
@@ -2,6 +2,8 @@ import { useEffect, useState } from 'react';
 import { css } from '@emotion/react';
 import SubdirectoryArrowRightOutlinedIcon from '@mui/icons-material/SubdirectoryArrowRightOutlined';
 import { Link, useLocation, useNavigate } from 'react-router-dom';
+import dayIcon from '@/assets/images/day-icon.png';
+import positionIcon from '@/assets/images/position-icon.png';
 import Button from '@/components/Button';
 import Modal from '@/components/Modal';
 import ProfileImage from '@/components/ProfileImage';
@@ -169,7 +171,8 @@ const AdminQnaDetail = () => {
         <div css={adminQStrategyStyle}>
           <div className='strategyName'>
             <div className='tag'>
-              <Tag src={data?.methodIconPath || ''} />
+              {data?.methodIconPath && <Tag src={data?.methodIconPath || ''} />}
+              <Tag src={data?.cycle === 'D' ? dayIcon : positionIcon} />
               {data?.stockList?.stockIconPath &&
                 data?.stockList?.stockIconPath.map(
                   (stock: string, index: number) => (

--- a/src/pages/admin/AdminQnaDetail.tsx
+++ b/src/pages/admin/AdminQnaDetail.tsx
@@ -199,30 +199,34 @@ const AdminQnaDetail = () => {
         <div css={adminQContentStyle}>
           <p>{data?.inquiryContent}</p>
         </div>
-        <div css={adminATitleStyle}>
-          <div className='answer'>
-            <div className='title'>
-              <SubdirectoryArrowRightOutlinedIcon css={iconStyle} />
-              <h6>{data?.answerTitle}</h6>
+        {data?.answerTitle && (
+          <>
+            <div css={adminATitleStyle}>
+              <div className='answer'>
+                <div className='title'>
+                  <SubdirectoryArrowRightOutlinedIcon css={iconStyle} />
+                  <h6>{data?.answerTitle}</h6>
+                </div>
+                <div className='info'>
+                  <p>작성일</p>
+                  <p>
+                    {inquiryDetailData?.data?.answerRegistrationDate &&
+                      formatYearMonthFromDateTime(
+                        inquiryDetailData?.data?.answerRegistrationDate
+                      )}
+                  </p>
+                </div>
+              </div>
+              <div className='profile'>
+                <ProfileImage src={data?.traderProfileImagePath} />
+                <p>{data?.traderNickname}</p>
+              </div>
             </div>
-            <div className='info'>
-              <p>작성일</p>
-              <p>
-                {inquiryDetailData?.data?.answerRegistrationDate &&
-                  formatYearMonthFromDateTime(
-                    inquiryDetailData?.data?.answerRegistrationDate
-                  )}
-              </p>
+            <div css={adminQContentStyle}>
+              <p>{data?.answerContent}</p>
             </div>
-          </div>
-          <div className='profile'>
-            <ProfileImage src={data?.traderProfileImagePath} />
-            <p>{data?.traderNickname}</p>
-          </div>
-        </div>
-        <div css={adminQContentStyle}>
-          <p>{data?.answerContent}</p>
-        </div>
+          </>
+        )}
       </div>
       <div css={adminQnaNavStyle}>
         {data?.previousId && (

--- a/src/pages/mypage/MyInterestList.tsx
+++ b/src/pages/mypage/MyInterestList.tsx
@@ -8,6 +8,8 @@ import {
 } from '@tanstack/react-query';
 import axios from 'axios';
 import { useNavigate } from 'react-router-dom';
+import dayIcon from '@/assets/images/day-icon.png';
+import positionIcon from '@/assets/images/position-icon.png';
 import Button from '@/components/Button';
 import Loading from '@/components/Loading';
 import Modal from '@/components/Modal';
@@ -30,7 +32,6 @@ import {
 import useModalStore from '@/stores/useModalStore';
 import { useTableStore } from '@/stores/useTableStore';
 import getColorStyleBasedOnValue from '@/utils/tableUtils';
-
 interface MyInterestListDataProps {
   ranking?: number;
   id: number;
@@ -40,7 +41,7 @@ interface MyInterestListDataProps {
   traderProfileImage: string;
   methodId: number;
   methodIconPath: string;
-  stockIconPath: string | null;
+  stockIconPath: string[] | null;
   cycle: string;
   stockList: {
     stockIds: number[];
@@ -239,7 +240,8 @@ const MyInterestList = () => {
     isEmpty: false,
   });
 
-  const { data: folderListData } = useGetUserFolderList();
+  const { data: folderListData, refetch: folderListRefetch } =
+    useGetUserFolderList();
   const { mutate: createFolderMutation } = useCreatFolder();
   const { mutate: updateFolderNameMutation } = useUpdateFolderName();
   const { mutate: checkFolderMutation } =
@@ -305,6 +307,7 @@ const MyInterestList = () => {
                             : folder
                         )
                       );
+                      folderListRefetch();
                       setEditingFolderId(null);
                       setTempFolderName('');
                     });
@@ -468,12 +471,11 @@ const MyInterestList = () => {
         <div css={tagStyle}>
           <div className='tag'>
             <Tag src={item?.methodIconPath || ''} alt='tag' />
-            {item?.stockList?.stockIconPath &&
-              item?.stockList?.stockIconPath.map(
-                (stock: string, index: number) => (
-                  <Tag key={index} src={stock} alt='tag' />
-                )
-              )}
+            <Tag src={item?.cycle === 'D' ? dayIcon : positionIcon} />
+            {item?.stockIconPath &&
+              item?.stockIconPath.map((stock: string, index: number) => (
+                <Tag key={index} src={stock} alt='tag' />
+              ))}
           </div>
           <span>{item.strategyName}</span>
         </div>
@@ -489,7 +491,7 @@ const MyInterestList = () => {
 
         return (
           <div css={fontStyle} style={colorStyle}>
-            {itemValue}%
+            {itemValue || 0}%
           </div>
         );
       },
@@ -504,7 +506,7 @@ const MyInterestList = () => {
 
         return (
           <div css={fontStyle} style={colorStyle}>
-            {itemValue}%
+            {itemValue || 0}%
           </div>
         );
       },
@@ -519,7 +521,7 @@ const MyInterestList = () => {
 
         return (
           <div css={fontStyle} style={colorStyle}>
-            {itemValue}%
+            {itemValue || 0}%
           </div>
         );
       },
@@ -904,10 +906,6 @@ const tableStyle = css`
     }
     &:nth-of-type(4) {
       text-align: left;
-      img {
-        width: ${FONT_SIZE.TEXT_MD};
-        height: ${FONT_SIZE.TEXT_MD};
-      }
     }
   }
 

--- a/src/pages/mypage/MyStrategyList.tsx
+++ b/src/pages/mypage/MyStrategyList.tsx
@@ -2,10 +2,13 @@ import { useEffect, useState } from 'react';
 import { css } from '@emotion/react';
 import { QueryObserverResult, RefetchOptions } from '@tanstack/react-query';
 import { useNavigate } from 'react-router-dom';
+import dayIcon from '@/assets/images/day-icon.png';
+import positionIcon from '@/assets/images/position-icon.png';
 import Button from '@/components/Button';
 import Modal from '@/components/Modal';
 import Pagination from '@/components/Pagination';
 import Table, { ColumnProps } from '@/components/Table';
+import Tag from '@/components/Tag';
 import { COLOR, COLOR_OPACITY } from '@/constants/color';
 import { FONT_SIZE, FONT_WEIGHT } from '@/constants/font';
 import { PATH } from '@/constants/path';
@@ -16,19 +19,24 @@ import {
 import useModalStore from '@/stores/useModalStore';
 import { useTableStore } from '@/stores/useTableStore';
 import getColorStyleBasedOnValue from '@/utils/tableUtils';
-
 interface MyStrategyListDataProps {
   ranking?: number;
   traderId: number;
   traderNickname: string;
   strategyId: number;
   methodId: number;
+  stockList: {
+    stockIds: number[];
+    stockNames: string[];
+    stockIconPath?: string[];
+  };
   cycle: string;
   name: string;
   mdd: number;
   smScore: number;
   accumulatedProfitLossRate: number;
   followerCount?: number;
+  methodIconPath: string;
   strategy?: any;
 }
 
@@ -153,6 +161,21 @@ const MyStrategyList = () => {
     {
       key: 'name',
       header: '전략명',
+      render: (_, item) => (
+        <div css={tagStyle}>
+          <div className='tag'>
+            <Tag src={item?.methodIconPath || ''} alt='tag' />
+            <Tag src={item?.cycle === 'D' ? dayIcon : positionIcon} />
+            {item?.stockList?.stockIconPath &&
+              item?.stockList?.stockIconPath.map(
+                (stock: string, index: number) => (
+                  <Tag key={index} src={stock} alt='tag' />
+                )
+              )}
+          </div>
+          <span>{item.name}</span>
+        </div>
+      ),
     },
     {
       key: 'accumulatedProfitLossRate',
@@ -375,6 +398,18 @@ const buttonStyle = css`
       background: ${COLOR_OPACITY.PRIMARY_OPACITY10};
       transition: 0.3s;
     }
+  }
+`;
+
+const tagStyle = css`
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 16px;
+
+  .tag {
+    display: flex;
+    gap: 4px;
   }
 `;
 

--- a/src/utils/dataUtils.ts
+++ b/src/utils/dataUtils.ts
@@ -30,5 +30,11 @@ export const formatYearMonth = (date: string) => {
   return `${year}. ${month}.`;
 };
 
-// T뒤에 제거해주는 날짜 함수
+// 'T' 뒤 제거해주는 날짜 함수
 export const extractDate = (dateTime: string) => dateTime?.split('T')[0];
+
+// 'T' 뒤 제거 후 'YYYY. MM.' 형식으로 포맷
+export const formatYearMonthFromDateTime = (dateTime: string) => {
+  const date = extractDate(dateTime);
+  return formatDate(date);
+};


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

담당 파트 수정

## 📋 작업 내용

- 관리자 문의페이지에서 아이콘 값이 null으로 올때 깨져보이는거, 기본값 줘서 안보이게 처리
- 로그인 시 공백포함 처리 가능하도록 수정
- 주기아이콘 추가
- 관리자 문의 페이지네이션 제대로 동작안함
- 폴더 생성 후 즉시 폴더목록 조회
- 전략 필터에서 종목 늘어날 시 css 대응
- 관리자 문의 상세 이전, 다음 수정(백엔드 api 수정중)
- 문의 상세 답변없으면 안보이게 처리


