### PR TITLE
[feat] 관리자 페이지 미완성 기능 구현

### DIFF
--- a/src/api/adminApi.ts
+++ b/src/api/adminApi.ts
@@ -146,6 +146,13 @@ export interface StocksPutRequestProps {
   file: File;
 }
 
+export interface AdminStrategyDtoProps {
+  openStatus?: string;
+  approvalStatus?: string;
+  keyword?: string;
+  page: number;
+}
+
 // 회원 목록 조회 API
 export const getAdminUserList = async (userList: AdminUserData) => {
   const queryParams = new URLSearchParams();
@@ -264,7 +271,18 @@ export const getAdminNoticeEdit = async (noticeId: string) => {
 };
 
 // 전략 목록 조회 API
-export const getAdminStrategyList = async () => {};
+export const getAdminStrategyList = async (params: AdminStrategyDtoProps) => {
+  const response = await axiosInstance.get(`/v1/admin/strategy`, {
+    params: {
+      openStatus: params.openStatus,
+      approvalStatus: params.approvalStatus,
+      keyword: params.keyword,
+      page: params.page,
+    },
+  });
+
+  return response.data;
+};
 
 // 전략 승인 API
 export const approveAdminStrategy = async (approveData: {
@@ -386,6 +404,34 @@ export const createAdminMethods = async (params: MethodsPostRequestProps) => {
   return response.data;
 };
 
+//매매방식 삭제 API
+export const deleteAdminMethods = async (ids: number[]) => {
+  const response = await axiosInstance.delete(`/v1/admin/method`, {
+    data: { methodIdList: ids },
+  });
+
+  return response.data;
+};
+
+//매매방식 수정 API
+export const updateAdminMethods = async (params: MethodsPutRequestProps) => {
+  const formData = new FormData();
+
+  formData.append(
+    'methodPutRequestDto',
+    JSON.stringify(params.methodPutRequestDto)
+  );
+  formData.append('file', params.file);
+
+  const response = await axiosInstance.put(`/v1/admin/method`, formData, {
+    headers: {
+      'Content-Type': 'multipart/form-data',
+    },
+  });
+
+  return response.data;
+};
+
 // 관리자 문의 조회 API
 export const getInquiryList = async (
   page: number,
@@ -416,37 +462,9 @@ export const deleteInquiryList = async (
   return response.data;
 };
 
-//매매방식 삭제 API
-export const deleteAdminMethods = async (ids: number[]) => {
-  const response = await axiosInstance.delete(`/v1/admin/method`, {
-    data: { methodIdList: ids },
-  });
-
-  return response.data;
-};
-
 // 관리자 문의 상세조회 API
 export const getAdminInquiryDetail = async (qnaId: number) => {
   const response = await axiosInstance.get(`/v1/admin/qna/${qnaId}`);
-
-  return response.data;
-};
-
-//매매방식 수정 API
-export const updateAdminMethods = async (params: MethodsPutRequestProps) => {
-  const formData = new FormData();
-
-  formData.append(
-    'methodPutRequestDto',
-    JSON.stringify(params.methodPutRequestDto)
-  );
-  formData.append('file', params.file);
-
-  const response = await axiosInstance.put(`/v1/admin/method`, formData, {
-    headers: {
-      'Content-Type': 'multipart/form-data',
-    },
-  });
 
   return response.data;
 };

--- a/src/api/adminApi.ts
+++ b/src/api/adminApi.ts
@@ -475,3 +475,10 @@ export const deleteDetailInquiry = async (qnaId: number) => {
 
   return response.data;
 };
+
+// 관리자 메인 조회 API
+export const getAdminMain = async () => {
+  const response = await axiosInstance.get(`/v1/admin/main`);
+
+  return response.data;
+};

--- a/src/hooks/useAdminApi.ts
+++ b/src/hooks/useAdminApi.ts
@@ -37,6 +37,7 @@ import {
   updateAdminStocks,
   AdminStrategyDtoProps,
   getAdminStrategyList,
+  getAdminMain,
 } from '@/api';
 
 export const useApproveAdminStrategy = () =>
@@ -221,4 +222,11 @@ export const useGetAdminStrategyList = (params: AdminStrategyDtoProps) =>
   useQuery({
     queryKey: ['adminStrategyList', params],
     queryFn: () => getAdminStrategyList(params),
+  });
+
+// 관리자 메인 조회
+export const useGetAdminMain = () =>
+  useQuery({
+    queryKey: ['adminMain'],
+    queryFn: () => getAdminMain(),
   });

--- a/src/hooks/useAdminApi.ts
+++ b/src/hooks/useAdminApi.ts
@@ -35,6 +35,8 @@ import {
   StocksParameterProps,
   updateAdminMethods,
   updateAdminStocks,
+  AdminStrategyDtoProps,
+  getAdminStrategyList,
 } from '@/api';
 
 export const useApproveAdminStrategy = () =>
@@ -212,4 +214,11 @@ export const useUpdateAdminUserRole = () =>
 export const useDeleteAdminUser = () =>
   useMutation({
     mutationFn: async (membersId: number[]) => deleteAdminUser(membersId),
+  });
+
+// 관리자 전략목록 조회
+export const useGetAdminStrategyList = (params: AdminStrategyDtoProps) =>
+  useQuery({
+    queryKey: ['adminStrategyList', params],
+    queryFn: () => getAdminStrategyList(params),
   });

--- a/src/pages/admin/Admin.tsx
+++ b/src/pages/admin/Admin.tsx
@@ -7,7 +7,7 @@ import { useNavigate } from 'react-router-dom';
 import Loading from '@/components/Loading';
 import TabButton from '@/components/TabButton';
 import { COLOR, COLOR_OPACITY } from '@/constants/color';
-import { FONT_SIZE } from '@/constants/font';
+import { FONT_SIZE, FONT_WEIGHT } from '@/constants/font';
 import { PATH } from '@/constants/path';
 import { useGetAdminMain } from '@/hooks/useAdminApi';
 
@@ -19,6 +19,7 @@ const Admin = () => {
   const { data, isLoading } = useGetAdminMain();
 
   const runReport = data?.data?.runReportResponseDto || {};
+  const runReportUrls = data?.data?.runReportResponseDto.topVisitedUrls || {};
   const memberCount = data?.data?.memberCount || {};
   const strategyCount = data?.data?.strategyCount || {};
   const inquiryCount = data?.data?.adminInquiryResponseDto || {};
@@ -36,7 +37,7 @@ const Admin = () => {
   };
 
   const handleNoticeClick = () => {
-    navigate(PATH.ADMIN_NOTICES_DETAIL(notices.noticeId));
+    navigate(PATH.ADMIN_NOTICES_DETAIL(notices[0].noticeId));
   };
 
   const handleTabClick = (value: SetStateAction<number>) => {
@@ -191,9 +192,14 @@ const Admin = () => {
           <div className='home-url-items'>
             <p>가장 많이 들른 URL</p>
             <div className='url'>
-              <p>1. www.naver.com</p>
-              <p>2. www.daum.net</p>
-              <p>3. www.google.com</p>
+              {Object.keys(runReportUrls)
+                .slice(0, 3)
+                .map((url, idx) => (
+                  <p key={url}>
+                    {idx + 1}. sysmetic.kr{url}
+                    <span>{runReportUrls[url]}</span>
+                  </p>
+                ))}
             </div>
           </div>
         </div>
@@ -452,6 +458,11 @@ const homeStyle = css`
       p {
         color: ${COLOR.TEXT_BLACK};
         font-size: ${FONT_SIZE.TEXT_MD};
+
+        span {
+          font-weight: ${FONT_WEIGHT.BOLD};
+          padding-left: 16px;
+        }
       }
     }
   }

--- a/src/pages/admin/Admin.tsx
+++ b/src/pages/admin/Admin.tsx
@@ -16,7 +16,7 @@ const Admin = () => {
   const [curTab, setCurTab] = useState(0);
   const navigate = useNavigate();
 
-  const { data, refetch, isLoading } = useGetAdminMain();
+  const { data, isLoading } = useGetAdminMain();
 
   const runReport = data?.data?.runReportResponseDto || {};
   const memberCount = data?.data?.memberCount || {};

--- a/src/pages/admin/Admin.tsx
+++ b/src/pages/admin/Admin.tsx
@@ -48,7 +48,11 @@ const Admin = () => {
   }, [tab]);
 
   if (isLoading) {
-    return <Loading />;
+    return (
+      <div css={loadingStyle}>
+        <Loading />
+      </div>
+    );
   }
 
   const DonutChart = () => {
@@ -490,6 +494,15 @@ const chartDataStyle = css`
     height: 14px;
     background-color: ${COLOR.PRIMARY600};
   }
+`;
+
+const loadingStyle = css`
+  width: 100%;
+  height: 100vh;
+  background-color: ${COLOR_OPACITY.PRIMARY100_OPACITY30};
+  display: flex;
+  justify-content: center;
+  align-items: center;
 `;
 
 export default Admin;

--- a/src/pages/admin/Admin.tsx
+++ b/src/pages/admin/Admin.tsx
@@ -1,13 +1,96 @@
-import { useState } from 'react';
+import { SetStateAction, useEffect, useState } from 'react';
 import { css } from '@emotion/react';
 import ArrowForwardIosOutlinedIcon from '@mui/icons-material/ArrowForwardIosOutlined';
+import Highcharts from 'highcharts';
+import HighchartsReact from 'highcharts-react-official';
+import { useNavigate } from 'react-router-dom';
+import Loading from '@/components/Loading';
 import TabButton from '@/components/TabButton';
 import { COLOR, COLOR_OPACITY } from '@/constants/color';
-import { FONT_SIZE, FONT_WEIGHT } from '@/constants/font';
+import { FONT_SIZE } from '@/constants/font';
+import { PATH } from '@/constants/path';
+import { useGetAdminMain } from '@/hooks/useAdminApi';
 
 const Admin = () => {
   const [tab, setTab] = useState(0);
   const [curTab, setCurTab] = useState(0);
+  const navigate = useNavigate();
+
+  const { data, refetch, isLoading } = useGetAdminMain();
+
+  const runReport = data?.data?.runReportResponseDto || {};
+  const memberCount = data?.data?.memberCount || {};
+  const strategyCount = data?.data?.strategyCount || {};
+  const inquiryCount = data?.data?.adminInquiryResponseDto || {};
+  const notices = data?.data?.adminNoticeResponse || [];
+
+  const handleStrategyClick = () => {
+    navigate(PATH.ADMIN_STRATEGIES);
+  };
+  const handleQnaClick = () => {
+    navigate(PATH.ADMIN_QNA);
+  };
+
+  const handleUserClick = () => {
+    navigate(PATH.ADMIN_USERS);
+  };
+
+  const handleNoticeClick = () => {
+    navigate(PATH.ADMIN_NOTICES_DETAIL(notices.noticeId));
+  };
+
+  const handleTabClick = (value: SetStateAction<number>) => {
+    setTab(value);
+  };
+
+  useEffect(() => {
+    setCurTab(tab);
+  }, [tab]);
+
+  if (isLoading) {
+    return <Loading />;
+  }
+
+  const DonutChart = () => {
+    const options = {
+      chart: {
+        type: 'pie',
+        width: 320,
+        height: 320,
+      },
+      title: {
+        text: `${new Date().toISOString().substring(0, 10)} 기준`,
+      },
+      plotOptions: {
+        pie: {
+          innerSize: '20%',
+          dataLabels: {
+            enabled: false,
+          },
+        },
+      },
+      series: [
+        {
+          name: '인원',
+          colorByPoint: true,
+          data: [
+            {
+              name: '트레이더',
+              y: memberCount.traderMemberCount,
+              color: COLOR.PRIMARY600,
+            },
+            {
+              name: '투자자',
+              y: memberCount.userMemberCount,
+              color: COLOR.PRIMARY200,
+            },
+          ],
+        },
+      ],
+    };
+
+    return <HighchartsReact highcharts={Highcharts} options={options} />;
+  };
 
   return (
     <div css={adminWrapperStyle}>
@@ -16,40 +99,46 @@ const Admin = () => {
           <div css={strategyStyle}>
             <div className='strategy-header'>
               <h6>전략 현황</h6>
-              <ArrowForwardIosOutlinedIcon />
+              <ArrowForwardIosOutlinedIcon
+                onClick={handleStrategyClick}
+                css={arrowStyle}
+              />
             </div>
             <div css={gridStyle}>
               <div className='r-items'>
                 <p>승인 대기중</p>
-                <h1>6</h1>
+                <h1>{strategyCount.waitingStrategyCount || 0}</h1>
               </div>
               <div className='str-items'>
                 <p>처리된 전략 수</p>
-                <h1>45</h1>
+                <h1>{strategyCount.openStrategyCount || 0}</h1>
               </div>
               <div className='str-items'>
                 <p>총 전략 수</p>
-                <h1>51</h1>
+                <h1>{strategyCount.totalStrategyCount || 0}</h1>
               </div>
             </div>
           </div>
           <div css={qnaStyle}>
             <div className='qna-header'>
               <h6>문의 현황</h6>
-              <ArrowForwardIosOutlinedIcon />
+              <ArrowForwardIosOutlinedIcon
+                onClick={handleQnaClick}
+                css={arrowStyle}
+              />
             </div>
             <div css={gridStyle}>
               <div className='b-items'>
                 <p>대기중인 문의</p>
-                <h1>6</h1>
+                <h1>{inquiryCount.waitingInquiryCount || 0}</h1>
               </div>
               <div className='qna-items'>
                 <p>완료된 문의</p>
-                <h1>45</h1>
+                <h1>{inquiryCount.answeredInquiryCount || 0}</h1>
               </div>
               <div className='qna-items'>
                 <p>총 문의수</p>
-                <h1>51</h1>
+                <h1>{inquiryCount.inquiryCount || 0}</h1>
               </div>
             </div>
           </div>
@@ -57,14 +146,29 @@ const Admin = () => {
         <div css={userStyle}>
           <div className='user-header'>
             <h6>회원 현황</h6>
-            <ArrowForwardIosOutlinedIcon />
+            <ArrowForwardIosOutlinedIcon
+              onClick={handleUserClick}
+              css={arrowStyle}
+            />
           </div>
-          <div className='chart'></div>
+          <div className='chart'>
+            <DonutChart />
+          </div>
+          <div className='chart-data'>
+            <div css={chartDataStyle}>
+              <div className='pixel-inv'></div>
+              <p>투자자</p>
+            </div>
+            <div css={chartDataStyle}>
+              <div className='pixel-tra'></div>
+              <p>트레이더</p>
+            </div>
+          </div>
           <div className='tab-btn'>
             <TabButton
               tabs={['1일', '1달', '1년']}
               currentTab={curTab}
-              handleTabChange={setTab}
+              handleTabChange={handleTabClick}
             />
           </div>
         </div>
@@ -74,26 +178,26 @@ const Admin = () => {
         <div css={gridStyle}>
           <div className='h-items'>
             <p>방문수</p>
-            <h1>51</h1>
+            <h1>{runReport.activeUser || 0}</h1>
           </div>
           <div className='home-items'>
             <p>평균 머문시간</p>
-            <h1>0.5</h1>
+            <h1>{runReport.avgSessionDuration || '0분 0초'}</h1>
           </div>
           <div className='home-url-items'>
             <p>가장 많이 들른 URL</p>
             <div className='url'>
-              <p>1. asdasda</p>
-              <p>2. sdadasdas</p>
-              <p>3. dassdasda</p>
+              <p>1. www.naver.com</p>
+              <p>2. www.daum.net</p>
+              <p>3. www.google.com</p>
             </div>
           </div>
         </div>
       </div>
       <div css={noticeStyle}>
         <h6>공지사항 현황</h6>
-        <p>시스메틱 내 '오늘의 투자'판이 출시됩니다!</p>
-        <span>2024. 11. 28</span>
+        <p onClick={handleNoticeClick}>{notices[0].noticeTitle}</p>
+        <span>{notices[0].noticeRegistrationDate}</span>
       </div>
     </div>
   );
@@ -165,13 +269,6 @@ const userStyle = css`
   padding: 42px 32px 24px;
   border-radius: 4px;
 
-  .chart {
-    width: 240px;
-    height: 240px;
-    background-color: ${COLOR.BLACK};
-    border-radius: 50%;
-  }
-
   .user-header {
     display: flex;
     justify-content: space-between;
@@ -180,6 +277,17 @@ const userStyle = css`
 
   .tab-btn {
     width: 334px;
+  }
+
+  .chart {
+    margin: 0 auto;
+  }
+
+  .chart-data {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    gap: 16px;
   }
 `;
 
@@ -310,6 +418,7 @@ const homeStyle = css`
     }
 
     h1 {
+      font-size: ${FONT_SIZE.TITLE_XL};
       display: flex;
       justify-content: flex-end;
     }
@@ -358,6 +467,29 @@ const noticeStyle = css`
   p {
     width: 800px;
     font-size: ${FONT_SIZE.TITLE_XS};
+    cursor: pointer;
   }
 `;
+
+const arrowStyle = css`
+  cursor: pointer;
+`;
+
+const chartDataStyle = css`
+  display: flex;
+  gap: 8px;
+
+  .pixel-inv {
+    width: 14px;
+    height: 14px;
+    background-color: ${COLOR.PRIMARY200};
+  }
+
+  .pixel-tra {
+    width: 14px;
+    height: 14px;
+    background-color: ${COLOR.PRIMARY600};
+  }
+`;
+
 export default Admin;

--- a/src/pages/admin/Admin.tsx
+++ b/src/pages/admin/Admin.tsx
@@ -1,3 +1,363 @@
-const Admin = () => <div>Admin</div>;
+import { useState } from 'react';
+import { css } from '@emotion/react';
+import ArrowForwardIosOutlinedIcon from '@mui/icons-material/ArrowForwardIosOutlined';
+import TabButton from '@/components/TabButton';
+import { COLOR, COLOR_OPACITY } from '@/constants/color';
+import { FONT_SIZE, FONT_WEIGHT } from '@/constants/font';
 
+const Admin = () => {
+  const [tab, setTab] = useState(0);
+  const [curTab, setCurTab] = useState(0);
+
+  return (
+    <div css={adminWrapperStyle}>
+      <div css={topDivStyle}>
+        <div css={innerDivStyle}>
+          <div css={strategyStyle}>
+            <div className='strategy-header'>
+              <h6>전략 현황</h6>
+              <ArrowForwardIosOutlinedIcon />
+            </div>
+            <div css={gridStyle}>
+              <div className='r-items'>
+                <p>승인 대기중</p>
+                <h1>6</h1>
+              </div>
+              <div className='str-items'>
+                <p>처리된 전략 수</p>
+                <h1>45</h1>
+              </div>
+              <div className='str-items'>
+                <p>총 전략 수</p>
+                <h1>51</h1>
+              </div>
+            </div>
+          </div>
+          <div css={qnaStyle}>
+            <div className='qna-header'>
+              <h6>문의 현황</h6>
+              <ArrowForwardIosOutlinedIcon />
+            </div>
+            <div css={gridStyle}>
+              <div className='b-items'>
+                <p>대기중인 문의</p>
+                <h1>6</h1>
+              </div>
+              <div className='qna-items'>
+                <p>완료된 문의</p>
+                <h1>45</h1>
+              </div>
+              <div className='qna-items'>
+                <p>총 문의수</p>
+                <h1>51</h1>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div css={userStyle}>
+          <div className='user-header'>
+            <h6>회원 현황</h6>
+            <ArrowForwardIosOutlinedIcon />
+          </div>
+          <div className='chart'></div>
+          <div className='tab-btn'>
+            <TabButton
+              tabs={['1일', '1달', '1년']}
+              currentTab={curTab}
+              handleTabChange={setTab}
+            />
+          </div>
+        </div>
+      </div>
+      <div css={homeStyle}>
+        <h6>홈페이지 현황</h6>
+        <div css={gridStyle}>
+          <div className='h-items'>
+            <p>방문수</p>
+            <h1>51</h1>
+          </div>
+          <div className='home-items'>
+            <p>평균 머문시간</p>
+            <h1>0.5</h1>
+          </div>
+          <div className='home-url-items'>
+            <p>가장 많이 들른 URL</p>
+            <div className='url'>
+              <p>1. asdasda</p>
+              <p>2. sdadasdas</p>
+              <p>3. dassdasda</p>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div css={noticeStyle}>
+        <h6>공지사항 현황</h6>
+        <p>시스메틱 내 '오늘의 투자'판이 출시됩니다!</p>
+        <span>2024. 11. 28</span>
+      </div>
+    </div>
+  );
+};
+
+const adminWrapperStyle = css`
+  width: 100%;
+  height: 100%;
+  padding: 96px 370px;
+  margin: 0 auto;
+  letter-spacing: -0.4px;
+  font-size: ${FONT_SIZE.TEXT_SM};
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  gap: 16px;
+  background-color: ${COLOR_OPACITY.PRIMARY100_OPACITY30};
+`;
+
+const topDivStyle = css`
+  display: flex;
+  gap: 16px;
+  max-width: 1180px;
+`;
+
+const innerDivStyle = css`
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+`;
+
+const strategyStyle = css`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: 22px;
+  background-color: ${COLOR.WHITE};
+  border-radius: 4px;
+  padding: 34px;
+
+  .strategy-header {
+    display: flex;
+    justify-content: space-between;
+  }
+`;
+
+const qnaStyle = css`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: 22px;
+  background-color: ${COLOR.WHITE};
+  border-radius: 4px;
+  padding: 34px;
+
+  .qna-header {
+    display: flex;
+    justify-content: space-between;
+  }
+`;
+
+const userStyle = css`
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+
+  background-color: ${COLOR.WHITE};
+  padding: 42px 32px 24px;
+  border-radius: 4px;
+
+  .chart {
+    width: 240px;
+    height: 240px;
+    background-color: ${COLOR.BLACK};
+    border-radius: 50%;
+  }
+
+  .user-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+  }
+
+  .tab-btn {
+    width: 334px;
+  }
+`;
+
+const gridStyle = css`
+  display: flex;
+  gap: 20px;
+
+  .str-items {
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    padding: 24px;
+    font-size: ${FONT_SIZE.TITLE_XS};
+    width: 220px;
+    height: 160px;
+    border: 1px solid ${COLOR.POINT};
+    border-radius: 4px;
+
+    p {
+      color: ${COLOR.POINT};
+    }
+
+    h1 {
+      display: flex;
+      justify-content: flex-end;
+    }
+  }
+
+  .qna-items {
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    padding: 24px;
+    font-size: ${FONT_SIZE.TITLE_XS};
+    width: 220px;
+    height: 160px;
+    border: 1px solid ${COLOR.PRIMARY};
+    border-radius: 4px;
+
+    p {
+      color: ${COLOR.PRIMARY};
+    }
+    h1 {
+      display: flex;
+      justify-content: flex-end;
+    }
+  }
+
+  .r-items {
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    padding: 24px;
+    font-size: ${FONT_SIZE.TITLE_XS};
+    color: ${COLOR.WHITE};
+    width: 220px;
+    height: 160px;
+    background-color: ${COLOR.POINT};
+    border-radius: 4px;
+
+    h1 {
+      display: flex;
+      justify-content: flex-end;
+    }
+  }
+
+  .b-items {
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    padding: 24px;
+    font-size: ${FONT_SIZE.TITLE_XS};
+    color: ${COLOR.WHITE};
+    width: 220px;
+    height: 160px;
+    background-color: ${COLOR.PRIMARY};
+    border-radius: 4px;
+
+    h1 {
+      display: flex;
+      justify-content: flex-end;
+    }
+  }
+`;
+
+const homeStyle = css`
+  display: flex;
+  flex-direction: column;
+  gap: 26px;
+  width: 1200px;
+  background-color: ${COLOR.WHITE};
+  border-radius: 4px;
+  height: 268px;
+  max-width: 1180px;
+  padding: 34px;
+
+  .h-items {
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    padding: 24px;
+    font-size: ${FONT_SIZE.TITLE_XS};
+    color: ${COLOR.WHITE};
+    width: 220px;
+    height: 160px;
+    background-color: ${COLOR.PRIMARY600};
+    border-radius: 4px;
+
+    h1 {
+      display: flex;
+      justify-content: flex-end;
+    }
+  }
+
+  .home-items {
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    padding: 24px;
+    font-size: ${FONT_SIZE.TITLE_XS};
+    width: 220px;
+    height: 160px;
+    border: 1px solid ${COLOR.PRIMARY600};
+    border-radius: 4px;
+
+    p {
+      color: ${COLOR.PRIMARY600};
+    }
+
+    h1 {
+      display: flex;
+      justify-content: flex-end;
+    }
+  }
+
+  .home-url-items {
+    display: flex;
+    font-size: ${FONT_SIZE.TITLE_XS};
+    flex-direction: column;
+    justify-content: space-between;
+    padding: 24px;
+    width: 630px;
+    height: 160px;
+    border: 1px solid ${COLOR.PRIMARY600};
+    border-radius: 4px;
+    gap: 20px;
+
+    p {
+      color: ${COLOR.PRIMARY600};
+    }
+
+    .url {
+      display: flex;
+      flex-direction: column;
+      gap: 12px;
+
+      p {
+        color: ${COLOR.TEXT_BLACK};
+        font-size: ${FONT_SIZE.TEXT_MD};
+      }
+    }
+  }
+`;
+
+const noticeStyle = css`
+  background-color: ${COLOR.WHITE};
+  border-radius: 4px;
+  width: 1200px;
+  height: 80px;
+  max-width: 1180px;
+  display: flex;
+  align-items: center;
+  padding: 28px 34px;
+  justify-content: space-between;
+
+  p {
+    width: 800px;
+    font-size: ${FONT_SIZE.TITLE_XS};
+  }
+`;
 export default Admin;

--- a/src/pages/admin/AdminStrategies.tsx
+++ b/src/pages/admin/AdminStrategies.tsx
@@ -191,7 +191,11 @@ const AdminStrategies = () => {
         </p>
       </div>
       <div css={startegytableStyle}>
-        <Table data={tableData} columns={columns} />
+        {totalElement > 0 ? (
+          <Table data={tableData} columns={columns} />
+        ) : (
+          <div className='no-data'> 전략이 존재하지 않습니다.</div>
+        )}
       </div>
       <div css={strategyPaginationStyle}>
         <Pagination
@@ -287,6 +291,17 @@ const startegytableStyle = css`
     &:nth-of-type(7) {
       width: 120px;
     }
+  }
+
+  .no-data {
+    height: 80px;
+    background-color: ${COLOR.GRAY100};
+    border-radius: 4px;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+
+    font-size: ${FONT_SIZE.TEXT_LG};
   }
 `;
 

--- a/src/pages/admin/AdminStrategies.tsx
+++ b/src/pages/admin/AdminStrategies.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import { css } from '@emotion/react';
 import SearchOutlinedIcon from '@mui/icons-material/SearchOutlined';
 import Button from '@/components/Button';
+import Loading from '@/components/Loading';
 import Pagination from '@/components/Pagination';
 import SelectBox from '@/components/SelectBox';
 import Table, { ColumnProps } from '@/components/Table';
@@ -12,7 +13,7 @@ import { FONT_SIZE, FONT_WEIGHT } from '@/constants/font';
 import { useGetAdminStrategyList } from '@/hooks/useAdminApi';
 
 export type OpenStatusTypes = 'PUBLIC' | 'PRIVATE';
-export type ApprovalStatusTypes = '요청 전' | '승인' | '반려' | '승인 요청';
+export type ApprovalStatusTypes = '승인요청' | '승인' | '반려' | '요청 전';
 
 interface AdminStrategyDataProps {
   strategyId: number;
@@ -38,10 +39,10 @@ const StatusOption = [
 ];
 
 const StagedOption = [
-  { label: '승인', value: '승인' },
-  { label: '반려', value: '반려' },
-  { label: '요청 전', value: '요청 전' },
-  { label: '승인 요청', value: '승인 요청' },
+  { label: '승인', value: 'SA002' },
+  { label: '반려', value: 'SA003' },
+  { label: '요청 전', value: 'SA000' },
+  { label: '승인 요청', value: 'SA001' },
 ];
 
 const AdminStrategies = () => {
@@ -49,21 +50,22 @@ const AdminStrategies = () => {
   const [selectedStatus, setSelectedStatus] = useState('');
   const [selectedStaged, setSelectedStaged] = useState('');
   const [value, SetValue] = useState('');
+  const [searchStatus, setSearchStatus] = useState('');
+  const [searchStaged, setSearchStaged] = useState('');
   const [searchKeyword, setSearchKeyword] = useState('');
   //테이블 관련
   const [curPage, setCurPage] = useState(0);
   const [totalPage, setTotalPage] = useState(0);
   const [totalElement, setTotalElement] = useState(0);
-  // const [pageSize, setPageSize] = useState(0);
   const [tableData, setTableData] = useState<AdminStrategyDataProps[]>([]);
   //데이터 관련
   const params = {
-    ...(selectedStatus && { openStatus: selectedStatus }),
-    ...(selectedStaged && { approvalStatus: selectedStaged }),
+    ...(searchStatus && { openStatus: searchStatus }),
+    ...(searchStaged && { approvalStatus: searchStaged }),
     ...(searchKeyword && { keyword: searchKeyword }),
     page: curPage,
   };
-  const { data, refetch } = useGetAdminStrategyList(params);
+  const { data, refetch, isLoading } = useGetAdminStrategyList(params);
 
   const handleStatusChange = (value: string) => {
     setSelectedStatus(value);
@@ -75,6 +77,8 @@ const AdminStrategies = () => {
 
   const handleIconClick = () => {
     setSearchKeyword(value);
+    setSearchStatus(selectedStatus);
+    setSearchStaged(selectedStaged);
     refetch();
   };
 
@@ -90,7 +94,6 @@ const AdminStrategies = () => {
     setTableData(data?.data?.content || []);
     setTotalPage(data?.data?.totalPages || 0);
     setTotalElement(data?.data?.totalElement || 0);
-    // setPageSize(data?.data?.pageSize || 0);
   }, [data]);
 
   const columns: ColumnProps<AdminStrategyDataProps>[] = [
@@ -191,7 +194,11 @@ const AdminStrategies = () => {
         </p>
       </div>
       <div css={startegytableStyle}>
-        {totalElement > 0 ? (
+        {isLoading ? (
+          <div css={loadingStyle}>
+            <Loading />
+          </div>
+        ) : totalElement > 0 ? (
           <Table data={tableData} columns={columns} />
         ) : (
           <div className='no-data'> 전략이 존재하지 않습니다.</div>
@@ -324,12 +331,19 @@ const tagStyle = css`
 `;
 
 const approvalStatusStyle = (approvalStatusCode: ApprovalStatusTypes) => css`
-  color: ${approvalStatusCode === '반려'
-    ? COLOR.ERROR_RED
+  color: ${approvalStatusCode === '승인요청'
+    ? COLOR.TEXT_BLACK
     : approvalStatusCode === '승인'
       ? COLOR.CHECK_GREEN
-      : approvalStatusCode === '요청 전'
-        ? COLOR.GRAY700
-        : COLOR.TEXT_BLACK};
+      : approvalStatusCode === '반려'
+        ? COLOR.ERROR_RED
+        : COLOR.GRAY700};
 `;
+
+const loadingStyle = css`
+  width: 100%;
+  height: 100vh;
+  padding: 100px;
+`;
+
 export default AdminStrategies;

--- a/src/pages/admin/AdminStrategies.tsx
+++ b/src/pages/admin/AdminStrategies.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useState } from 'react';
 import { css } from '@emotion/react';
 import SearchOutlinedIcon from '@mui/icons-material/SearchOutlined';
-import TagTest from '@/assets/images/test-tag.jpg';
 import Button from '@/components/Button';
 import Pagination from '@/components/Pagination';
 import SelectBox from '@/components/SelectBox';
@@ -12,8 +11,8 @@ import { COLOR, COLOR_OPACITY } from '@/constants/color';
 import { FONT_SIZE, FONT_WEIGHT } from '@/constants/font';
 import { useGetAdminStrategyList } from '@/hooks/useAdminApi';
 
-type OpenStatusTypes = 'PUBLIC' | 'PRIVATE';
-type ApprovalStatusTypes = '요청 전' | '승인' | '반려' | '승인 요청';
+export type OpenStatusTypes = 'PUBLIC' | 'PRIVATE';
+export type ApprovalStatusTypes = '요청 전' | '승인' | '반려' | '승인 요청';
 
 interface AdminStrategyDataProps {
   strategyId: number;
@@ -39,10 +38,10 @@ const StatusOption = [
 ];
 
 const StagedOption = [
-  { label: '승인', value: 'approval' },
-  { label: '반려', value: 'companion' },
-  { label: '요청전', value: 'unstaged' },
-  { label: '승인요청', value: 'staging' },
+  { label: '승인', value: '승인' },
+  { label: '반려', value: '반려' },
+  { label: '요청 전', value: '요청 전' },
+  { label: '승인 요청', value: '승인 요청' },
 ];
 
 const AdminStrategies = () => {
@@ -50,6 +49,7 @@ const AdminStrategies = () => {
   const [selectedStatus, setSelectedStatus] = useState('');
   const [selectedStaged, setSelectedStaged] = useState('');
   const [value, SetValue] = useState('');
+  const [searchKeyword, setSearchKeyword] = useState('');
   //테이블 관련
   const [curPage, setCurPage] = useState(0);
   const [totalPage, setTotalPage] = useState(0);
@@ -57,14 +57,13 @@ const AdminStrategies = () => {
   // const [pageSize, setPageSize] = useState(0);
   const [tableData, setTableData] = useState<AdminStrategyDataProps[]>([]);
   //데이터 관련
-
   const params = {
     ...(selectedStatus && { openStatus: selectedStatus }),
     ...(selectedStaged && { approvalStatus: selectedStaged }),
-    ...(value && { keyword: value }),
+    ...(searchKeyword && { keyword: searchKeyword }),
     page: curPage,
   };
-  const { data } = useGetAdminStrategyList(params);
+  const { data, refetch } = useGetAdminStrategyList(params);
 
   const handleStatusChange = (value: string) => {
     setSelectedStatus(value);
@@ -75,7 +74,8 @@ const AdminStrategies = () => {
   };
 
   const handleIconClick = () => {
-    console.log(value);
+    setSearchKeyword(value);
+    refetch();
   };
 
   useEffect(() => {
@@ -129,7 +129,7 @@ const AdminStrategies = () => {
       key: 'openStatusCode' as keyof AdminStrategyDataProps,
       header: '공개여부',
       render: (_, item) =>
-        item.openStatusCode === 'PRIVATE' ? '공개' : '비공개',
+        item.openStatusCode === 'PUBLIC' ? '공개' : '비공개',
     },
     {
       key: 'approvalStatusCode' as keyof AdminStrategyDataProps,

--- a/src/pages/admin/AdminStrategies.tsx
+++ b/src/pages/admin/AdminStrategies.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import { css } from '@emotion/react';
 import SearchOutlinedIcon from '@mui/icons-material/SearchOutlined';
+import { useNavigate } from 'react-router-dom';
 import Button from '@/components/Button';
 import Loading from '@/components/Loading';
 import Pagination from '@/components/Pagination';
@@ -10,6 +11,7 @@ import Tag from '@/components/Tag';
 import TextInput from '@/components/TextInput';
 import { COLOR, COLOR_OPACITY } from '@/constants/color';
 import { FONT_SIZE, FONT_WEIGHT } from '@/constants/font';
+import { PATH } from '@/constants/path';
 import { useGetAdminStrategyList } from '@/hooks/useAdminApi';
 
 export type OpenStatusTypes = 'PUBLIC' | 'PRIVATE';
@@ -46,6 +48,7 @@ const StagedOption = [
 ];
 
 const AdminStrategies = () => {
+  const navigate = useNavigate();
   // 필드 관련
   const [selectedStatus, setSelectedStatus] = useState('');
   const [selectedStaged, setSelectedStaged] = useState('');
@@ -146,7 +149,7 @@ const AdminStrategies = () => {
     {
       key: 'state' as keyof AdminStrategyDataProps,
       header: '상태',
-      render: () => (
+      render: (_, item) => (
         <div css={buttonStyle}>
           <Button
             label='상세관리'
@@ -155,7 +158,9 @@ const AdminStrategies = () => {
             color='primary'
             border={true}
             width={80}
-            handleClick={() => {}}
+            handleClick={() =>
+              navigate(PATH.ADMIN_STRATEGIES_CONTROL(String(item.strategyId)))
+            }
           />
         </div>
       ),

--- a/src/pages/admin/AdminStrategies.tsx
+++ b/src/pages/admin/AdminStrategies.tsx
@@ -8,18 +8,14 @@ import SelectBox from '@/components/SelectBox';
 import Table, { ColumnProps } from '@/components/Table';
 import Tag from '@/components/Tag';
 import TextInput from '@/components/TextInput';
-import { COLOR_OPACITY } from '@/constants/color';
+import { COLOR, COLOR_OPACITY } from '@/constants/color';
 import { FONT_SIZE, FONT_WEIGHT } from '@/constants/font';
 import { useGetAdminStrategyList } from '@/hooks/useAdminApi';
 
 type OpenStatusTypes = 'PUBLIC' | 'PRIVATE';
+type ApprovalStatusTypes = '요청 전' | '승인' | '반려' | '승인 요청';
+
 interface AdminStrategyDataProps {
-  // no: number;
-  // traderName: string;
-  // strategyName: string;
-  // enrollDate: string;
-  // isOn: boolean;
-  // staged: string;
   strategyId: number;
   strategyName: string;
   traderName: string;
@@ -28,7 +24,7 @@ interface AdminStrategyDataProps {
   methodId: string;
   methodIconPath: string;
   stockList: StockListProps;
-  approvalStatusCode: string; //TODO: 단계 뭐뭐있는지?
+  approvalStatusCode: ApprovalStatusTypes; //TODO: 단계 뭐뭐있는지?
 }
 
 interface StockListProps {
@@ -138,6 +134,11 @@ const AdminStrategies = () => {
     {
       key: 'approvalStatusCode' as keyof AdminStrategyDataProps,
       header: '승인단계',
+      render: (_, item) => (
+        <p css={approvalStatusStyle(item.approvalStatusCode)}>
+          {item.approvalStatusCode}
+        </p>
+      ),
     },
     {
       key: 'state' as keyof AdminStrategyDataProps,
@@ -307,4 +308,13 @@ const tagStyle = css`
   }
 `;
 
+const approvalStatusStyle = (approvalStatusCode: ApprovalStatusTypes) => css`
+  color: ${approvalStatusCode === '반려'
+    ? COLOR.ERROR_RED
+    : approvalStatusCode === '승인'
+      ? COLOR.CHECK_GREEN
+      : approvalStatusCode === '요청 전'
+        ? COLOR.GRAY700
+        : COLOR.TEXT_BLACK};
+`;
 export default AdminStrategies;

--- a/src/pages/admin/AdminStrategies.tsx
+++ b/src/pages/admin/AdminStrategies.tsx
@@ -109,13 +109,18 @@ const AdminStrategies = () => {
     {
       key: 'strategyName' as keyof AdminStrategyDataProps,
       header: '전략명',
-      render: (
-        value: string | number | undefined | boolean | StockListProps
-      ) => (
+      render: (_, item) => (
         <div css={tagStyle}>
-          <div>
-            <Tag src={value as string} alt='tag' />
+          <div className='tag'>
+            <Tag src={item?.methodIconPath || ''} />
+            {item?.stockList?.stockIconPath &&
+              item?.stockList?.stockIconPath.map(
+                (stock: string, index: number) => (
+                  <Tag key={index} src={stock || ''} alt='tag' />
+                )
+              )}
           </div>
+          {item.strategyName}
         </div>
       ),
     },
@@ -295,6 +300,11 @@ const tagStyle = css`
   flex-direction: column;
   gap: 12px;
   align-items: flex-start;
+
+  .tag {
+    display: flex;
+    gap: 4px;
+  }
 `;
 
 export default AdminStrategies;


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

**관리자 메인 페이지, 관리자 전략목록 기능 구현**

## 📋 작업 내용

- 관리자 메인 페이지 퍼블리싱 및 기능 구현
- 관리자 전략목록 기능구현

## 📸 스크린샷 (선택 사항)

### 관리자 메인
![adminMain2](https://github.com/user-attachments/assets/3c00bc94-dc51-44f8-bcac-87dd86944f5c)


### 전략목록
![strategyDetail](https://github.com/user-attachments/assets/fe420631-287c-4d88-a296-a47ecfe097db)



## 📄 기타

- 그래프에 탭버튼 있어야할지? -> 현재 기능 X
- 공지사항 롤링 추후 구현
